### PR TITLE
Fix issue with multiple suffixes and capitalization

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -620,4 +620,4 @@ class HumanName(object):
         self.first_list  = self.cap_piece(self.first ).split(' ')
         self.middle_list = self.cap_piece(self.middle).split(' ')
         self.last_list   = self.cap_piece(self.last  ).split(' ')
-        self.suffix_list = self.cap_piece(self.suffix).split(' ')
+        self.suffix_list = self.cap_piece(self.suffix).split(', ')


### PR DESCRIPTION
As mentioned in #14, when the nameparser is passed a name like "SAHNI, ARU MD PHD", the suffix property is joined by a comma and a space. When `capitalize()` is called, the `HumanName.suffix` property is only split on space, resulting in trailing commas in the first n-1 `suffix_list` entries.

fixes #14
