### PR TITLE
add simple postprocessing

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -44,7 +44,8 @@ class HumanName(object):
         a :py:class:`~nameparser.config.Constants` instance. Pass ``None`` for 
         `per-instance config <customize.html>`_. 
     :param str encoding: string representing the encoding of your input
-    :param str string_format: python string formatting 
+    :param str string_format: python string formatting
+    :param bool postprocessing: apply postprocessing after finish of parsing 
     """
     
     has_own_config = False
@@ -68,9 +69,11 @@ class HumanName(object):
     _full_name = ''
     
     def __init__(self, full_name="", constants=CONSTANTS, encoding=ENCODING, 
-                string_format=None):
+                string_format=None, postprocessing=False):
         global CONSTANTS
         self.C = constants
+        self.postprocessing = postprocessing
+        self.symbols ='@!&+*'
         if not self.C:
             self.C = Constants()
         if self.C is not CONSTANTS:
@@ -175,7 +178,7 @@ class HumanName(object):
         :py:mod:`~nameparser.config.titles` or :py:mod:`~nameparser.config.conjunctions`
         at the beginning of :py:attr:`full_name`.
         """
-        return " ".join(self.title_list)
+        return self._postprocessing(" ".join(self.title_list))
     
     @property
     def first(self):
@@ -183,7 +186,7 @@ class HumanName(object):
         The person's first name. The first name piece after any known 
         :py:attr:`title` pieces parsed from :py:attr:`full_name`.
         """
-        return " ".join(self.first_list)
+        return self._postprocessing(" ".join(self.first_list))
     
     @property
     def middle(self):
@@ -191,7 +194,7 @@ class HumanName(object):
         The person's middle names. All name pieces after the first name and before 
         the last name parsed from :py:attr:`full_name`.
         """
-        return " ".join(self.middle_list)
+        return self._postprocessing(" ".join(self.middle_list))
     
     @property
     def last(self):
@@ -199,7 +202,7 @@ class HumanName(object):
         The person's last name. The last name piece parsed from 
         :py:attr:`full_name`.
         """
-        return " ".join(self.last_list)
+        return self._postprocessing(" ".join(self.last_list))
     
     @property
     def suffix(self):
@@ -209,7 +212,7 @@ class HumanName(object):
         of comma separated formats, e.g. "Lastname, Title Firstname Middle[,] Suffix 
         [, Suffix]" parsed from :py:attr:`full_name`.
         """
-        return ", ".join(self.suffix_list)
+        return self._postprocessing(", ".join(self.suffix_list))
     
     @property
     def nickname(self):
@@ -217,7 +220,7 @@ class HumanName(object):
         The person's nicknames. Any text found inside of quotes (``""``) or 
         parenthesis (``()``)
         """
-        return " ".join(self.nickname_list)
+        return self._postprocessing(" ".join(self.nickname_list))
     
     ### setter methods
     
@@ -657,3 +660,16 @@ class HumanName(object):
         self.middle_list = self.cap_piece(self.middle).split(' ')
         self.last_list   = self.cap_piece(self.last  ).split(' ')
         self.suffix_list = self.cap_piece(self.suffix).split(', ')
+
+    ### Postprocessing
+
+    def apply_postprocessing(self, delete_symbols='@!&+*'):
+        self.postprocessing = True
+        self.symbols = delete_symbols
+
+    def _remove_symbols(self, data):
+        return ''.join([symbol for symbol in data if symbol not in self.symbols])
+
+    def _postprocessing(self, data):
+        if self.postprocessing: return self._remove_symbols(data)
+        else: return data

--- a/tests.py
+++ b/tests.py
@@ -1634,6 +1634,35 @@ class HumanNameCapitalizationTestCase(HumanNameTestBase):
         hn.capitalize()
         self.m(str(hn), 'Ronald McDonald', hn)
 
+class PostProcessingTestCase(HumanNameTestBase):
+    def test_clear_nickname(self):
+        hn = HumanName("Franklin, Benjamin (@Ben), Jr.", postprocessing=True)
+        self.m(hn.nickname, "Ben", hn)
+
+    def test_clear_title(self):
+        hn = HumanName(".Mag-Judge Harwell G Davis, III")
+        hn.apply_postprocessing(delete_symbols='.')
+        self.m(hn.title, "Mag-Judge", hn)
+
+    def test_clear_last_name(self):
+        hn = HumanName("US Magistrate Judge T Michael Putnam*", postprocessing=True)
+        self.m(hn.last, "Putnam", hn)
+
+    def test_clear_first_name(self):
+         hn = HumanName("&Duke& Martin Luther King, Jr.", postprocessing=True)
+         self.m(hn.first, "Duke", hn)
+
+    def test_apply_postprocessing(self):
+        hn = HumanName("Franklin, Benjamin (@Ben), Jr.")
+        hn.apply_postprocessing()
+        self.m(hn.nickname, "Ben", hn)
+
+    def test_apply_postprocessing2(self):
+        hn = HumanName(".Cardinal Secretary of State Hillary Clinton")
+        self.m(hn.title, ".Cardinal Secretary of State", hn)
+        hn.apply_postprocessing(delete_symbols='.')
+        self.m(hn.title, "Cardinal Secretary of State", hn)
+
 
 class HumanNameOutputFormatTests(HumanNameTestBase):
     def test_formating(self):


### PR DESCRIPTION
Hi!
I've just a made simple extension for removing excess symbolsfrom the result. For example
```python
name = HumanName("Mick (@mickjagger) Jagger")
print(name.nickname) # shows @mickjagger
```
With parameter "postprocessing", we getting clear nickname
```python
name = HumanName("Mick '@mickjagger' Jagger",postprocessing=True)
print(name.nickname) # shows mickjagger
```

Also, we can define own rule for removing symbols
```python
name = HumanName(".Mag-Judge Harwell G Davis, III")
name.apply_postprocessing(delete_symbols='.')
print(name.title) #shows Mag-Judge
```
What do you think?