### PR TITLE
Adding common doctor titles

### DIFF
--- a/nameparser/config/titles.py
+++ b/nameparser/config/titles.py
@@ -404,5 +404,7 @@ TITLES = FIRST_NAME_TITLES | set([
     'mag-judge',
     'senior-judge',
     'mag/judge',
+    'md',
+    'do'
     
 ])


### PR DESCRIPTION
Doctor of Medicine (M.D.) and Doctor of Osteopathic Medicine (D.O.) are commonly used as suffix or prefix in a name (with or w/o the dot notation)
IE: Louis Hache, M.D.