### PR TITLE
include tests in release source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include AUTHORS
 include LICENSE
 include README.rst
+include tests.py


### PR DESCRIPTION
It is useful for end users to have tests to ensure the package is working correctly.

I've been working on building a package of this software to include in Debian GNU/Linux. During the package build process it is very helpful to be able to run the tests.

I also plan to run the tests frequently using the Debian continuous integration infrastructure. This will help to catch any regressions across the Python ecosystem within Debian.

Other distributions will find the tests useful for the same reason.