### PR TITLE
Skip another pickle test if dill isn't installed.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -77,6 +77,7 @@ class HumanNamePythonTests(HumanNameTestBase):
         hn = HumanName("John Doe")
         self.m(len(hn), 2, hn)
 
+    @unittest.skipUnless(dill,"requires python-dill module to test pickling")
     def test_config_pickle(self):
         C = Constants()
         self.assertTrue(dill.pickles(C))


### PR DESCRIPTION
Fixes this test failure when `dill` isn't installed:

```
ERROR: test_config_pickle (__main__.HumanNamePythonTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 82, in test_config_pickle
    self.assertTrue(dill.pickles(C))
AttributeError: 'bool' object has no attribute 'pickles'

----------------------------------------------------------------------
Ran 261 tests in 0.150s

FAILED (errors=1, skipped=1, expected failures=11)
```
