### PR TITLE
Move all simple unit tests into JSON file

### DIFF
--- a/testnames.json
+++ b/testnames.json
@@ -15,7 +15,7 @@
         "last" : "la"
     },
     "_blank_name" : {
-        "name : "",
+        "name" : "",
         "first" : "",
         "last" : ""
     },

--- a/testnames.json
+++ b/testnames.json
@@ -1190,7 +1190,7 @@
         "last" : "Ma",
         "suffix" : "III, Jr"
     },
-    "_suffix_with_periods" : {
+    "_suffix_with_periods2" : {
         "name" : "John Doe Msc.Ed.",
         "first" : "John",
         "last" : "Doe",

--- a/testnames.json
+++ b/testnames.json
@@ -1,1399 +1,1399 @@
 {
     "_utf8" : {
-        name : "de la Véña, Jüan",
-        first : "Jüan",
-        last : "de la Véña"
+        "name" : "de la Véña, Jüan",
+        "first" : "Jüan",
+        "last" : "de la Véña"
     },
     "_escaped_utf8_bytes" : {
-        name : b'B\xc3\xb6ck, Gerald',
-        first : "Gerald",
-        last : "Böck"
+        "name" : b'B\xc3\xb6ck, Gerald',
+        "first" : "Gerald",
+        "last" : "Böck"
     },
     "_conjunction_names" : {
-        name : "johnny y",
-        first : "johnny",
-        last : "y"
+        "name" : "johnny y",
+        "first" : "johnny",
+        "last" : "y"
     },
     "_prefix_names" : {
-        name : "vai la",
-        first : "vai",
-        last : "la"
+        "name" : "vai la",
+        "first" : "vai",
+        "last" : "la"
     },
     "_blank_name" : {
-        name = "",
-        first : "",
-        last : ""
+        "name : "",
+        "first" : "",
+        "last" : ""
     },
     "_first_name" : {
-        name : "Andrew",
-        first : "Andrew"
+        "name" : "Andrew",
+        "first" : "Andrew"
     },
     "_assume_title_and_one_other_name_is_last_name" : {
-        name : "Rev Andrews",
-        title : "Rev",
-        last : "Andrews"
+        "name" : "Rev Andrews",
+        "title" : "Rev",
+        "last" : "Andrews"
     },
     "_suffix_in_lastname_part_of_lastname_comma_format" : {
-        name : "Smith Jr., John",
-        last : "Smith",
-        first : "John",
-        suffix : "Jr."
+        "name" : "Smith Jr., John",
+        "last" : "Smith",
+        "first" : "John",
+        "suffix" : "Jr."
     },
     "_sir_exception_to_first_name_rule" : {
-        name : "Sir Gerald",
-        title : "Sir",
-        first : "Gerald"
+        "name" : "Sir Gerald",
+        "title" : "Sir",
+        "first" : "Gerald"
     },
     "_king_exception_to_first_name_rule" : {
-        name : "King Henry",
-        title : "King",
-        first : "Henry"
+        "name" : "King Henry",
+        "title" : "King",
+        "first" : "Henry"
     },
     "_queen_exception_to_first_name_rule" : {
-        name : "Queen Elizabeth",
-        title : "Queen",
-        first : "Elizabeth"
+        "name" : "Queen Elizabeth",
+        "title" : "Queen",
+        "first" : "Elizabeth"
     },
     "_dame_exception_to_first_name_rule" : {
-        name : "Dame Mary",
-        title : "Dame",
-        first : "Mary"
+        "name" : "Dame Mary",
+        "title" : "Dame",
+        "first" : "Mary"
     },
     "_first_name_is_not_prefix_if_only_two_parts_comma" : {
-        name : "Nguyen, Van",
-        first : "Van",
-        last : "Nguyen"
+        "name" : "Nguyen, Van",
+        "first" : "Van",
+        "last" : "Nguyen"
     },
     "1" : {
-        name : "John Doe",
-        first : "John",
-        last : "Doe"
+        "name" : "John Doe",
+        "first" : "John",
+        "last" : "Doe"
     },
     "2" : {
-        name : "John Doe, Jr.",
-        first : "John",
-        last : "Doe",
-        suffix : "Jr."
+        "name" : "John Doe, Jr.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "Jr."
     },
     "3" : {
-        name : "John Doe III",
-        first : "John",
-        last : "Doe",
-        suffix : "III"
+        "name" : "John Doe III",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "III"
     },
     "4" : {
-        name : "Doe, John",
-        first : "John",
-        last : "Doe"
+        "name" : "Doe, John",
+        "first" : "John",
+        "last" : "Doe"
     },
     "5" : {
-        name : "Doe, John, Jr.",
-        first : "John",
-        last : "Doe",
-        suffix : "Jr."
+        "name" : "Doe, John, Jr.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "Jr."
     },
     "6" : {
-        name : "Doe, John III",
-        first : "John",
-        last : "Doe",
-        suffix : "III"
+        "name" : "Doe, John III",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "III"
     },
     "7" : {
-        name : "John A. Doe",
-        first : "John",
-        last : "Doe",
-        middle : "A."
+        "name" : "John A. Doe",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A."
     },
     "8" : {
-        name : "John A. Doe, Jr",
-        first : "John",
-        last : "Doe",
-        middle : "A.",
-        suffix : "Jr"
+        "name" : "John A. Doe, Jr",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A.",
+        "suffix" : "Jr"
     },
     "9" : {
-        name : "John A. Doe III",
-        first : "John",
-        last : "Doe",
-        middle : "A.",
-        suffix : "III"
+        "name" : "John A. Doe III",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A.",
+        "suffix" : "III"
     },
     "10" : {
-        name : "Doe, John A.",
-        first : "John",
-        last : "Doe",
-        middle : "A."
+        "name" : "Doe, John A.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A."
     },
     "11" : {
-        name : "Doe, John A., Jr.",
-        first : "John",
-        last : "Doe",
-        middle : "A.",
-        suffix : "Jr."
+        "name" : "Doe, John A., Jr.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A.",
+        "suffix" : "Jr."
     },
     "12" : {
-        name : "Doe, John A., III",
-        first : "John",
-        last : "Doe",
-        middle : "A.",
-        suffix : "III"
+        "name" : "Doe, John A., III",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A.",
+        "suffix" : "III"
     },
     "13" : {
-        name : "John A. Kenneth Doe",
-        first : "John",
-        last : "Doe",
-        middle : "A. Kenneth"
+        "name" : "John A. Kenneth Doe",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A. Kenneth"
     },
     "14" : {
-        name : "John A. Kenneth Doe, Jr.",
-        first : "John",
-        last : "Doe",
-        middle : "A. Kenneth",
-        suffix : "Jr."
+        "name" : "John A. Kenneth Doe, Jr.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A. Kenneth",
+        "suffix" : "Jr."
     },
     "15" : {
-        name : "John A. Kenneth Doe III",
-        first : "John",
-        last : "Doe",
-        middle : "A. Kenneth",
-        suffix : "III"
+        "name" : "John A. Kenneth Doe III",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A. Kenneth",
+        "suffix" : "III"
     },
     "16" : {
-        name : "Doe, John. A. Kenneth",
-        first : "John.",
-        last : "Doe",
-        middle : "A. Kenneth"
+        "name" : "Doe, John. A. Kenneth",
+        "first" : "John.",
+        "last" : "Doe",
+        "middle" : "A. Kenneth"
     },
     "17" : {
-        name : "Doe, John. A. Kenneth, Jr.",
-        first : "John.",
-        last : "Doe",
-        middle : "A. Kenneth",
-        suffix : "Jr."
+        "name" : "Doe, John. A. Kenneth, Jr.",
+        "first" : "John.",
+        "last" : "Doe",
+        "middle" : "A. Kenneth",
+        "suffix" : "Jr."
     },
     "18" : {
-        name : "Doe, John. A. Kenneth III",
-        first : "John.",
-        last : "Doe",
-        middle : "A. Kenneth",
-        suffix : "III"
+        "name" : "Doe, John. A. Kenneth III",
+        "first" : "John.",
+        "last" : "Doe",
+        "middle" : "A. Kenneth",
+        "suffix" : "III"
     },
     "19" : {
-        name : "Dr. John Doe",
-        first : "John",
-        last : "Doe",
-        title : "Dr."
+        "name" : "Dr. John Doe",
+        "first" : "John",
+        "last" : "Doe",
+        "title" : "Dr."
     },
     "20" : {
-        name : "Dr. John Doe, Jr.",
-        title : "Dr.",
-        first : "John",
-        last : "Doe",
-        suffix : "Jr."
+        "name" : "Dr. John Doe, Jr.",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "Jr."
     },
     "21" : {
-        name : "Dr. John Doe III",
-        title : "Dr.",
-        first : "John",
-        last : "Doe",
-        suffix : "III"
+        "name" : "Dr. John Doe III",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "III"
     },
     "22" : {
-        name : "Doe, Dr. John",
-        title : "Dr.",
-        first : "John",
-        last : "Doe"
+        "name" : "Doe, Dr. John",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe"
     },
     "23" : {
-        name : "Doe, Dr. John, Jr.",
-        title : "Dr.",
-        first : "John",
-        last : "Doe",
-        suffix : "Jr."
+        "name" : "Doe, Dr. John, Jr.",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "Jr."
     },
     "24" : {
-        name : "Doe, Dr. John III",
-        title : "Dr.",
-        first : "John",
-        last : "Doe",
-        suffix : "III"
+        "name" : "Doe, Dr. John III",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "III"
     },
     "25" : {
-        name : "Dr. John A. Doe",
-        title : "Dr.",
-        first : "John",
-        last : "Doe",
-        middle : "A."
+        "name" : "Dr. John A. Doe",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A."
     },
     "26" : {
-        name : "Dr. John A. Doe, Jr.",
-        title : "Dr.",
-        first : "John",
-        last : "Doe",
-        middle : "A.",
-        suffix : "Jr."
+        "name" : "Dr. John A. Doe, Jr.",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A.",
+        "suffix" : "Jr."
     },
     "27" : {
-        name : "Dr. John A. Doe III",
-        title : "Dr.",
-        first : "John",
-        last : "Doe",
-        middle : "A.",
-        suffix : "III"
+        "name" : "Dr. John A. Doe III",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A.",
+        "suffix" : "III"
     },
     "28" : {
-        name : "Doe, Dr. John A.",
-        title : "Dr.",
-        first : "John",
-        last : "Doe",
-        middle : "A."
+        "name" : "Doe, Dr. John A.",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A."
     },
     "29" : {
-        name : "Doe, Dr. John A. Jr.",
-        title : "Dr.",
-        first : "John",
-        last : "Doe",
-        middle : "A.",
-        suffix : "Jr."
+        "name" : "Doe, Dr. John A. Jr.",
+        "title" : "Dr.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A.",
+        "suffix" : "Jr."
     },
     "30" : {
-        name : "Doe, Dr. John A. III",
-        title : "Dr.",
-        middle : "A.",
-        first : "John",
-        last : "Doe",
-        suffix : "III"
+        "name" : "Doe, Dr. John A. III",
+        "title" : "Dr.",
+        "middle" : "A.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "III"
     },
     "31" : {
-        name : "Dr. John A. Kenneth Doe",
-        title : "Dr.",
-        middle : "A. Kenneth",
-        first : "John",
-        last : "Doe"
+        "name" : "Dr. John A. Kenneth Doe",
+        "title" : "Dr.",
+        "middle" : "A. Kenneth",
+        "first" : "John",
+        "last" : "Doe"
     },
     "32" : {
-        name : "Dr. John A. Kenneth Doe, Jr.",
-        title : "Dr.",
-        middle : "A. Kenneth",
-        first : "John",
-        last : "Doe",
-        suffix : "Jr."
+        "name" : "Dr. John A. Kenneth Doe, Jr.",
+        "title" : "Dr.",
+        "middle" : "A. Kenneth",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "Jr."
     },
     "33" : {
-        name : "Al Arnold Gore, Jr.",
-        middle : "Arnold",
-        first : "Al",
-        last : "Gore",
-        suffix : "Jr."
+        "name" : "Al Arnold Gore, Jr.",
+        "middle" : "Arnold",
+        "first" : "Al",
+        "last" : "Gore",
+        "suffix" : "Jr."
     },
     "34" : {
-        name : "Dr. John A. Kenneth Doe III",
-        title : "Dr.",
-        middle : "A. Kenneth",
-        first : "John",
-        last : "Doe",
-        suffix : "III"
+        "name" : "Dr. John A. Kenneth Doe III",
+        "title" : "Dr.",
+        "middle" : "A. Kenneth",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "III"
     },
     "35" : {
-        name : "Doe, Dr. John A. Kenneth",
-        title : "Dr.",
-        middle : "A. Kenneth",
-        first : "John",
-        last : "Doe"
+        "name" : "Doe, Dr. John A. Kenneth",
+        "title" : "Dr.",
+        "middle" : "A. Kenneth",
+        "first" : "John",
+        "last" : "Doe"
     },
     "36" : {
-        name : "Doe, Dr. John A. Kenneth Jr.",
-        title : "Dr.",
-        middle : "A. Kenneth",
-        first : "John",
-        last : "Doe",
-        suffix : "Jr."
+        "name" : "Doe, Dr. John A. Kenneth Jr.",
+        "title" : "Dr.",
+        "middle" : "A. Kenneth",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "Jr."
     },
     "37" : {
-        name : "Doe, Dr. John A. Kenneth III",
-        title : "Dr.",
-        middle : "A. Kenneth",
-        first : "John",
-        last : "Doe",
-        suffix : "III"
+        "name" : "Doe, Dr. John A. Kenneth III",
+        "title" : "Dr.",
+        "middle" : "A. Kenneth",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "III"
     },
     "38" : {
-        name : "Juan de la Vega",
-        first : "Juan",
-        last : "de la Vega"
+        "name" : "Juan de la Vega",
+        "first" : "Juan",
+        "last" : "de la Vega"
     },
     "39" : {
-        name : "Juan de la Vega, Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        suffix : "Jr."
+        "name" : "Juan de la Vega, Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "suffix" : "Jr."
     },
     "40" : {
-        name : "Juan de la Vega III",
-        first : "Juan",
-        last : "de la Vega",
-        suffix : "III"
+        "name" : "Juan de la Vega III",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "suffix" : "III"
     },
     "41" : {
-        name : "de la Vega, Juan",
-        first : "Juan",
-        last : "de la Vega"
+        "name" : "de la Vega, Juan",
+        "first" : "Juan",
+        "last" : "de la Vega"
     },
     "42" : {
-        name : "de la Vega, Juan, Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        suffix : "Jr."
+        "name" : "de la Vega, Juan, Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "suffix" : "Jr."
     },
     "43" : {
-        name : "de la Vega, Juan III",
-        first : "Juan",
-        last : "de la Vega",
-        suffix : "III"
+        "name" : "de la Vega, Juan III",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "suffix" : "III"
     },
     "44" : {
-        name : "Juan Velasquez y Garcia",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Juan Velasquez y Garcia",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "45" : {
-        name : "Juan Velasquez y Garcia, Jr.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Juan Velasquez y Garcia, Jr.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "46" : {
-        name : "Juan Velasquez y Garcia III",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Juan Velasquez y Garcia III",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "47" : {
-        name : "Velasquez y Garcia, Juan",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Velasquez y Garcia, Juan",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "48" : {
-        name : "Velasquez y Garcia, Juan, Jr.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Velasquez y Garcia, Juan, Jr.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "49" : {
-        name : "Velasquez y Garcia, Juan III",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Velasquez y Garcia, Juan III",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "50" : {
-        name : "Dr. Juan de la Vega",
-        title : "Dr.",
-        first : "Juan",
-        last : "de la Vega"
+        "name" : "Dr. Juan de la Vega",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "de la Vega"
     },
     "51" : {
-        name : "Dr. Juan de la Vega, Jr.",
-        title : "Dr.",
-        first : "Juan",
-        last : "de la Vega",
-        suffix : "Jr."
+        "name" : "Dr. Juan de la Vega, Jr.",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "suffix" : "Jr."
     },
     "52" : {
-        name : "Dr. Juan de la Vega III",
-        title : "Dr.",
-        first : "Juan",
-        last : "de la Vega",
-        suffix : "III"
+        "name" : "Dr. Juan de la Vega III",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "suffix" : "III"
     },
     "53" : {
-        name : "de la Vega, Dr. Juan",
-        title : "Dr.",
-        first : "Juan",
-        last : "de la Vega"
+        "name" : "de la Vega, Dr. Juan",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "de la Vega"
     },
     "54" : {
-        name : "de la Vega, Dr. Juan, Jr.",
-        title : "Dr.",
-        first : "Juan",
-        last : "de la Vega",
-        suffix : "Jr."
+        "name" : "de la Vega, Dr. Juan, Jr.",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "suffix" : "Jr."
     },
     "55" : {
-        name : "de la Vega, Dr. Juan III",
-        title : "Dr.",
-        first : "Juan",
-        last : "de la Vega",
-        suffix : "III"
+        "name" : "de la Vega, Dr. Juan III",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "suffix" : "III"
     },
     "56" : {
-        name : "Dr. Juan Velasquez y Garcia",
-        title : "Dr.",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Dr. Juan Velasquez y Garcia",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "57" : {
-        name : "Dr. Juan Velasquez y Garcia, Jr.",
-        title : "Dr.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Dr. Juan Velasquez y Garcia, Jr.",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "58" : {
-        name : "Dr. Juan Velasquez y Garcia III",
-        title : "Dr.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Dr. Juan Velasquez y Garcia III",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "59" : {
-        name : "Velasquez y Garcia, Dr. Juan",
-        title : "Dr.",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Velasquez y Garcia, Dr. Juan",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "60" : {
-        name : "Velasquez y Garcia, Dr. Juan, Jr.",
-        title : "Dr.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Velasquez y Garcia, Dr. Juan, Jr.",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "61" : {
-        name : "Velasquez y Garcia, Dr. Juan III",
-        title : "Dr.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Velasquez y Garcia, Dr. Juan III",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "62" : {
-        name : "Juan Q. de la Vega",
-        first : "Juan",
-        middle : "Q.",
-        last : "de la Vega"
+        "name" : "Juan Q. de la Vega",
+        "first" : "Juan",
+        "middle" : "Q.",
+        "last" : "de la Vega"
     },
     "63" : {
-        name : "Juan Q. de la Vega, Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q.",
-        suffix : "Jr."
+        "name" : "Juan Q. de la Vega, Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q.",
+        "suffix" : "Jr."
     },
     "64" : {
-        name : "Juan Q. de la Vega III",
-        first : "Juan",
-        middle : "Q.",
-        last : "de la Vega",
-        suffix : "III"
+        "name" : "Juan Q. de la Vega III",
+        "first" : "Juan",
+        "middle" : "Q.",
+        "last" : "de la Vega",
+        "suffix" : "III"
     },
     "65" : {
-        name : "de la Vega, Juan Q.",
-        first : "Juan",
-        middle : "Q.",
-        last : "de la Vega"
+        "name" : "de la Vega, Juan Q.",
+        "first" : "Juan",
+        "middle" : "Q.",
+        "last" : "de la Vega"
     },
     "66" : {
-        name : "de la Vega, Juan Q., Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q.",
-        suffix : "Jr."
+        "name" : "de la Vega, Juan Q., Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q.",
+        "suffix" : "Jr."
     },
     "67" : {
-        name : "de la Vega, Juan Q. III",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q.",
-        suffix : "III"
+        "name" : "de la Vega, Juan Q. III",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q.",
+        "suffix" : "III"
     },
     "68" : {
-        name : "Juan Q. Velasquez y Garcia",
-        middle : "Q.",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Juan Q. Velasquez y Garcia",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "69" : {
-        name : "Juan Q. Velasquez y Garcia, Jr.",
-        middle : "Q.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Juan Q. Velasquez y Garcia, Jr.",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "70" : {
-        name : "Juan Q. Velasquez y Garcia III",
-        middle : "Q.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Juan Q. Velasquez y Garcia III",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "71" : {
-        name : "Velasquez y Garcia, Juan Q.",
-        middle : "Q.",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Velasquez y Garcia, Juan Q.",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "72" : {
-        name : "Velasquez y Garcia, Juan Q., Jr.",
-        middle : "Q.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Velasquez y Garcia, Juan Q., Jr.",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "73" : {
-        name : "Velasquez y Garcia, Juan Q. III",
-        middle : "Q.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Velasquez y Garcia, Juan Q. III",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "74" : {
-        name : "Dr. Juan Q. de la Vega",
-        title : "Dr.",
-        first : "Juan",
-        middle : "Q.",
-        last : "de la Vega"
+        "name" : "Dr. Juan Q. de la Vega",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "middle" : "Q.",
+        "last" : "de la Vega"
     },
     "75" : {
-        name : "Dr. Juan Q. de la Vega, Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q.",
-        title : "Dr.",
-        suffix : "Jr."
+        "name" : "Dr. Juan Q. de la Vega, Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q.",
+        "title" : "Dr.",
+        "suffix" : "Jr."
     },
     "76" : {
-        name : "Dr. Juan Q. de la Vega III",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q.",
-        title : "Dr.",
-        suffix : "III"
+        "name" : "Dr. Juan Q. de la Vega III",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q.",
+        "title" : "Dr.",
+        "suffix" : "III"
     },
     "77" : {
-        name : "de la Vega, Dr. Juan Q.",
-        first : "Juan",
-        middle : "Q.",
-        last : "de la Vega",
-        title : "Dr."
+        "name" : "de la Vega, Dr. Juan Q.",
+        "first" : "Juan",
+        "middle" : "Q.",
+        "last" : "de la Vega",
+        "title" : "Dr."
     },
     "78" : {
-        name : "de la Vega, Dr. Juan Q., Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q.",
-        suffix : "Jr.",
-        title : "Dr."
+        "name" : "de la Vega, Dr. Juan Q., Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q.",
+        "suffix" : "Jr.",
+        "title" : "Dr."
     },
     "79" : {
-        name : "de la Vega, Dr. Juan Q. III",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q.",
-        suffix : "III",
-        title : "Dr."
+        "name" : "de la Vega, Dr. Juan Q. III",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q.",
+        "suffix" : "III",
+        "title" : "Dr."
     },
     "80" : {
-        name : "Dr. Juan Q. Velasquez y Garcia",
-        title : "Dr.",
-        middle : "Q.",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Dr. Juan Q. Velasquez y Garcia",
+        "title" : "Dr.",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "81" : {
-        name : "Dr. Juan Q. Velasquez y Garcia, Jr.",
-        title : "Dr.",
-        middle : "Q.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Dr. Juan Q. Velasquez y Garcia, Jr.",
+        "title" : "Dr.",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "82" : {
-        name : "Dr. Juan Q. Velasquez y Garcia III",
-        middle : "Q.",
-        title : "Dr.",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Dr. Juan Q. Velasquez y Garcia III",
+        "middle" : "Q.",
+        "title" : "Dr.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "83" : {
-        name : "Velasquez y Garcia, Dr. Juan Q.",
-        title : "Dr.",
-        middle : "Q.",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Velasquez y Garcia, Dr. Juan Q.",
+        "title" : "Dr.",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "84" : {
-        name : "Velasquez y Garcia, Dr. Juan Q., Jr.",
-        middle : "Q.",
-        first : "Juan",
-        title : "Dr.",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Velasquez y Garcia, Dr. Juan Q., Jr.",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "title" : "Dr.",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "85" : {
-        name : "Velasquez y Garcia, Dr. Juan Q. III",
-        middle : "Q.",
-        first : "Juan",
-        title : "Dr.",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Velasquez y Garcia, Dr. Juan Q. III",
+        "middle" : "Q.",
+        "first" : "Juan",
+        "title" : "Dr.",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "86" : {
-        name : "Juan Q. Xavier de la Vega",
-        first : "Juan",
-        middle : "Q. Xavier",
-        last : "de la Vega"
+        "name" : "Juan Q. Xavier de la Vega",
+        "first" : "Juan",
+        "middle" : "Q. Xavier",
+        "last" : "de la Vega"
     },
     "87" : {
-        name : "Juan Q. Xavier de la Vega, Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q. Xavier",
-        suffix : "Jr."
+        "name" : "Juan Q. Xavier de la Vega, Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q. Xavier",
+        "suffix" : "Jr."
     },
     "88" : {
-        name : "Juan Q. Xavier de la Vega III",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q. Xavier",
-        suffix : "III"
+        "name" : "Juan Q. Xavier de la Vega III",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q. Xavier",
+        "suffix" : "III"
     },
     "89" : {
-        name : "de la Vega, Juan Q. Xavier",
-        first : "Juan",
-        middle : "Q. Xavier",
-        last : "de la Vega"
+        "name" : "de la Vega, Juan Q. Xavier",
+        "first" : "Juan",
+        "middle" : "Q. Xavier",
+        "last" : "de la Vega"
     },
     "90" : {
-        name : "de la Vega, Juan Q. Xavier, Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q. Xavier",
-        suffix : "Jr."
+        "name" : "de la Vega, Juan Q. Xavier, Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q. Xavier",
+        "suffix" : "Jr."
     },
     "91" : {
-        name : "de la Vega, Juan Q. Xavier III",
-        first : "Juan",
-        last : "de la Vega",
-        middle : "Q. Xavier",
-        suffix : "III"
+        "name" : "de la Vega, Juan Q. Xavier III",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "middle" : "Q. Xavier",
+        "suffix" : "III"
     },
     "92" : {
-        name : "Dr. Juan Q. Xavier de la Vega",
-        first : "Juan",
-        middle : "Q. Xavier",
-        title : "Dr.",
-        last : "de la Vega"
+        "name" : "Dr. Juan Q. Xavier de la Vega",
+        "first" : "Juan",
+        "middle" : "Q. Xavier",
+        "title" : "Dr.",
+        "last" : "de la Vega"
     },
     "93" : {
-        name : "Dr. Juan Q. Xavier de la Vega, Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        title : "Dr.",
-        middle : "Q. Xavier",
-        suffix : "Jr."
+        "name" : "Dr. Juan Q. Xavier de la Vega, Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "title" : "Dr.",
+        "middle" : "Q. Xavier",
+        "suffix" : "Jr."
     },
     "94" : {
-        name : "Dr. Juan Q. Xavier de la Vega III",
-        first : "Juan",
-        last : "de la Vega",
-        title : "Dr.",
-        middle : "Q. Xavier",
-        suffix : "III"
+        "name" : "Dr. Juan Q. Xavier de la Vega III",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "title" : "Dr.",
+        "middle" : "Q. Xavier",
+        "suffix" : "III"
     },
     "95" : {
-        name : "de la Vega, Dr. Juan Q. Xavier",
-        first : "Juan",
-        title : "Dr.",
-        middle : "Q. Xavier",
-        last : "de la Vega"
+        "name" : "de la Vega, Dr. Juan Q. Xavier",
+        "first" : "Juan",
+        "title" : "Dr.",
+        "middle" : "Q. Xavier",
+        "last" : "de la Vega"
     },
     "96" : {
-        name : "de la Vega, Dr. Juan Q. Xavier, Jr.",
-        first : "Juan",
-        last : "de la Vega",
-        title : "Dr.",
-        middle : "Q. Xavier",
-        suffix : "Jr."
+        "name" : "de la Vega, Dr. Juan Q. Xavier, Jr.",
+        "first" : "Juan",
+        "last" : "de la Vega",
+        "title" : "Dr.",
+        "middle" : "Q. Xavier",
+        "suffix" : "Jr."
     },
     "97" : {
-        name : "de la Vega, Dr. Juan Q. Xavier III",
-        first : "Juan",
-        title : "Dr.",
-        last : "de la Vega",
-        middle : "Q. Xavier",
-        suffix : "III"
+        "name" : "de la Vega, Dr. Juan Q. Xavier III",
+        "first" : "Juan",
+        "title" : "Dr.",
+        "last" : "de la Vega",
+        "middle" : "Q. Xavier",
+        "suffix" : "III"
     },
     "98" : {
-        name : "Juan Q. Xavier Velasquez y Garcia",
-        middle : "Q. Xavier",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Juan Q. Xavier Velasquez y Garcia",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "99" : {
-        name : "Juan Q. Xavier Velasquez y Garcia, Jr.",
-        middle : "Q. Xavier",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Juan Q. Xavier Velasquez y Garcia, Jr.",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "100" : {
-        name : "Juan Q. Xavier Velasquez y Garcia III",
-        middle : "Q. Xavier",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Juan Q. Xavier Velasquez y Garcia III",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "101" : {
-        name : "Velasquez y Garcia, Juan Q. Xavier",
-        middle : "Q. Xavier",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Velasquez y Garcia, Juan Q. Xavier",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "102" : {
-        name : "Velasquez y Garcia, Juan Q. Xavier, Jr.",
-        middle : "Q. Xavier",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Velasquez y Garcia, Juan Q. Xavier, Jr.",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "103" : {
-        name : "Velasquez y Garcia, Juan Q. Xavier III",
-        middle : "Q. Xavier",
-        first : "Juan",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Velasquez y Garcia, Juan Q. Xavier III",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "104" : {
-        name : "Dr. Juan Q. Xavier Velasquez y Garcia",
-        title : "Dr.",
-        middle : "Q. Xavier",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Dr. Juan Q. Xavier Velasquez y Garcia",
+        "title" : "Dr.",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "105" : {
-        name : "Dr. Juan Q. Xavier Velasquez y Garcia, Jr.",
-        middle : "Q. Xavier",
-        first : "Juan",
-        title : "Dr.",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Dr. Juan Q. Xavier Velasquez y Garcia, Jr.",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "title" : "Dr.",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "106" : {
-        name : "Dr. Juan Q. Xavier Velasquez y Garcia III",
-        middle : "Q. Xavier",
-        first : "Juan",
-        title : "Dr.",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Dr. Juan Q. Xavier Velasquez y Garcia III",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "title" : "Dr.",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "107" : {
-        name : "Velasquez y Garcia, Dr. Juan Q. Xavier",
-        title : "Dr.",
-        middle : "Q. Xavier",
-        first : "Juan",
-        last : "Velasquez y Garcia"
+        "name" : "Velasquez y Garcia, Dr. Juan Q. Xavier",
+        "title" : "Dr.",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "last" : "Velasquez y Garcia"
     },
     "108" : {
-        name : "Velasquez y Garcia, Dr. Juan Q. Xavier, Jr.",
-        middle : "Q. Xavier",
-        first : "Juan",
-        title : "Dr.",
-        last : "Velasquez y Garcia",
-        suffix : "Jr."
+        "name" : "Velasquez y Garcia, Dr. Juan Q. Xavier, Jr.",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "title" : "Dr.",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "Jr."
     },
     "109" : {
-        name : "Velasquez y Garcia, Dr. Juan Q. Xavier III",
-        middle : "Q. Xavier",
-        first : "Juan",
-        title : "Dr.",
-        last : "Velasquez y Garcia",
-        suffix : "III"
+        "name" : "Velasquez y Garcia, Dr. Juan Q. Xavier III",
+        "middle" : "Q. Xavier",
+        "first" : "Juan",
+        "title" : "Dr.",
+        "last" : "Velasquez y Garcia",
+        "suffix" : "III"
     },
     "110" : {
-        name : "John Doe, CLU, CFP, LUTC",
-        first : "John",
-        last : "Doe",
-        suffix : "CLU, CFP, LUTC"
+        "name" : "John Doe, CLU, CFP, LUTC",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "CLU, CFP, LUTC"
     },
     "111" : {
-        name : "John P. Doe, CLU, CFP, LUTC",
-        first : "John",
-        middle : "P.",
-        last : "Doe",
-        suffix : "CLU, CFP, LUTC"
+        "name" : "John P. Doe, CLU, CFP, LUTC",
+        "first" : "John",
+        "middle" : "P.",
+        "last" : "Doe",
+        "suffix" : "CLU, CFP, LUTC"
     },
     "112" : {
-        name : "Dr. John P. Doe-Ray, CLU, CFP, LUTC",
-        first : "John",
-        middle : "P.",
-        last : "Doe-Ray",
-        title : "Dr.",
-        suffix : "CLU, CFP, LUTC"
+        "name" : "Dr. John P. Doe-Ray, CLU, CFP, LUTC",
+        "first" : "John",
+        "middle" : "P.",
+        "last" : "Doe-Ray",
+        "title" : "Dr.",
+        "suffix" : "CLU, CFP, LUTC"
     },
     "113" : {
-        name : "Doe-Ray, Dr. John P., CLU, CFP, LUTC",
-        title : "Dr.",
-        middle : "P.",
-        first : "John",
-        last : "Doe-Ray",
-        suffix : "CLU, CFP, LUTC"
+        "name" : "Doe-Ray, Dr. John P., CLU, CFP, LUTC",
+        "title" : "Dr.",
+        "middle" : "P.",
+        "first" : "John",
+        "last" : "Doe-Ray",
+        "suffix" : "CLU, CFP, LUTC"
     },
     "115" : {
-        name : "Hon. Barrington P. Doe-Ray, Jr.",
-        title : "Hon.",
-        middle : "P.",
-        first : "Barrington",
-        last : "Doe-Ray"
+        "name" : "Hon. Barrington P. Doe-Ray, Jr.",
+        "title" : "Hon.",
+        "middle" : "P.",
+        "first" : "Barrington",
+        "last" : "Doe-Ray"
     },
     "116" : {
-        name : "Doe-Ray, Hon. Barrington P. Jr., CFP, LUTC",
-        title : "Hon.",
-        middle : "P.",
-        first : "Barrington",
-        last : "Doe-Ray",
-        suffix : "Jr., CFP, LUTC"
+        "name" : "Doe-Ray, Hon. Barrington P. Jr., CFP, LUTC",
+        "title" : "Hon.",
+        "middle" : "P.",
+        "first" : "Barrington",
+        "last" : "Doe-Ray",
+        "suffix" : "Jr., CFP, LUTC"
     },
     "117" : {
-        name : "Rt. Hon. Paul E. Mary",
-        title : "Rt. Hon.",
-        first : "Paul",
-        middle : "E.",
-        last : "Mary"
+        "name" : "Rt. Hon. Paul E. Mary",
+        "title" : "Rt. Hon.",
+        "first" : "Paul",
+        "middle" : "E.",
+        "last" : "Mary"
     },
     "119" : {
-        name : "Lord God Almighty",
-        title : "Lord",
-        first : "God",
-        last : "Almighty"
+        "name" : "Lord God Almighty",
+        "title" : "Lord",
+        "first" : "God",
+        "last" : "Almighty"
     },
     "_last_name_with_conjunction" : {
-        name : 'Jose Aznar y Lopez',
-        first : "Jose",
-        last : "Aznar y Lopez"
+        "name" : 'Jose Aznar y Lopez',
+        "first" : "Jose",
+        "last" : "Aznar y Lopez"
     },
     "_multiple_conjunctions" : {
-        name : "part1 of The part2 of the part3 and part4",
-        first : "part1 of The part2 of the part3 and part4"
+        "name" : "part1 of The part2 of the part3 and part4",
+        "first" : "part1 of The part2 of the part3 and part4"
     },
     "_multiple_conjunctions2" : {
-        name : "part1 of and The part2 of the part3 And part4",
-        first : "part1 of and The part2 of the part3 And part4"
+        "name" : "part1 of and The part2 of the part3 And part4",
+        "first" : "part1 of and The part2 of the part3 And part4"
     },
     "_ends_with_conjunction" : {
-        name : "Jon Dough and",
-        first : "Jon",
-        last : "Dough and"
+        "name" : "Jon Dough and",
+        "first" : "Jon",
+        "last" : "Dough and"
     },
     "_ends_with_two_conjunctions" : {
-        name : "Jon Dough and of",
-        first : "Jon",
-        last : "Dough and of"
+        "name" : "Jon Dough and of",
+        "first" : "Jon",
+        "last" : "Dough and of"
     },
     "_starts_with_conjunction" : {
-        name : "and Jon Dough",
-        first : "and Jon",
-        last : "Dough"
+        "name" : "and Jon Dough",
+        "first" : "and Jon",
+        "last" : "Dough"
     },
     "_starts_with_two_conjunctions" : {
-        name : "the and Jon Dough",
-        first : "the and Jon",
-        last : "Dough"
+        "name" : "the and Jon Dough",
+        "first" : "the and Jon",
+        "last" : "Dough"
     },
     "_uppercase_middle_initial_conflict_with_conjunction" : {
-        name : 'John E Smith',
-        first : "John",
-        middle : "E",
-        last : "Smith"
+        "name" : 'John E Smith',
+        "first" : "John",
+        "middle" : "E",
+        "last" : "Smith"
     },
     "_lowercase_middle_initial_with_period_conflict_with_conjunction" : {
-        name : 'john e. smith',
-        first : "john",
-        middle : "e.",
-        last : "smith"
+        "name" : 'john e. smith',
+        "first" : "john",
+        "middle" : "e.",
+        "last" : "smith"
     },
     "_lowercase_first_initial_conflict_with_conjunction" : {
-        name : 'e j smith',
-        first : "e",
-        middle : "j",
-        last : "smith"
+        "name" : 'e j smith',
+        "first" : "e",
+        "middle" : "j",
+        "last" : "smith"
     },
     "_lowercase_middle_initial_conflict_with_conjunction" : {
-        name : 'John e Smith',
-        first : "John",
-        middle : "e",
-        last : "Smith"
+        "name" : 'John e Smith',
+        "first" : "John",
+        "middle" : "e",
+        "last" : "Smith"
     },
     "_lowercase_middle_initial_and_suffix_conflict_with_conjunction" : {
-        name : 'John e Smith, III',
-        first : "John",
-        middle : "e",
-        last : "Smith",
-        suffix : "III"
+        "name" : 'John e Smith, III',
+        "first" : "John",
+        "middle" : "e",
+        "last" : "Smith",
+        "suffix" : "III"
     },
     "_lowercase_middle_initial_and_nocomma_suffix_conflict_with_conjunction" : {
-        name : 'John e Smith III',
-        first : "John",
-        middle : "e",
-        last : "Smith",
-        suffix : "III"
+        "name" : 'John e Smith III',
+        "first" : "John",
+        "middle" : "e",
+        "last" : "Smith",
+        "suffix" : "III"
     },
     "_lowercase_middle_initial_comma_lastname_and_suffix_conflict_with_conjunction" : {
-        name : 'Smith, John e, III, Jr',
-        first : "John",
-        middle : "e",
-        last : "Smith",
-        suffix : "III, Jr"
+        "name" : 'Smith, John e, III, Jr',
+        "first" : "John",
+        "middle" : "e",
+        "last" : "Smith",
+        "suffix" : "III, Jr"
     },
     "_couples_names" : {
-        name : 'John and Jane Smith',
-        first : "John and Jane",
-        last : "Smith"
+        "name" : 'John and Jane Smith',
+        "first" : "John and Jane",
+        "last" : "Smith"
     },
     "_couples_names_with_conjunction_lastname" : {
-        name : 'John and Jane Aznar y Lopez',
-        first : "John and Jane",
-        last : "Aznar y Lopez"
+        "name" : 'John and Jane Aznar y Lopez',
+        "first" : "John and Jane",
+        "last" : "Aznar y Lopez"
     },
     "_couple_titles" : {
-        name : 'Mr. and Mrs. John and Jane Smith',
-        title : "Mr. and Mrs.",
-        first : "John and Jane",
-        last : "Smith"
+        "name" : 'Mr. and Mrs. John and Jane Smith',
+        "title" : "Mr. and Mrs.",
+        "first" : "John and Jane",
+        "last" : "Smith"
     },
     "_title_with_three_part_name_last_initial_is_suffix_uppercase_no_period" : {
-        name : "King John Alexander V",
-        title : "King",
-        first : "John",
-        last : "Alexander",
-        suffix : "V"
+        "name" : "King John Alexander V",
+        "title" : "King",
+        "first" : "John",
+        "last" : "Alexander",
+        "suffix" : "V"
     },
     "_four_name_parts_with_suffix_that_could_be_initial_lowercase_no_period" : {
-        name : "larry james edward johnson v",
-        first : "larry",
-        middle : "james edward",
-        last : "johnson",
-        suffix : "v"
+        "name" : "larry james edward johnson v",
+        "first" : "larry",
+        "middle" : "james edward",
+        "last" : "johnson",
+        "suffix" : "v"
     },
     "_four_name_parts_with_suffix_that_could_be_initial_uppercase_no_period" : {
-        name : "Larry James Johnson I",
-        first : "Larry",
-        middle : "James",
-        last : "Johnson",
-        suffix : "I"
+        "name" : "Larry James Johnson I",
+        "first" : "Larry",
+        "middle" : "James",
+        "last" : "Johnson",
+        "suffix" : "I"
     },
     "_roman_numeral_initials" : {
-        name : "Larry V I",
-        first : "Larry",
-        middle : "V",
-        last : "I",
-        suffix : ""
+        "name" : "Larry V I",
+        "first" : "Larry",
+        "middle" : "V",
+        "last" : "I",
+        "suffix" : ""
     },
     "124" : {
-        name : "Rev. John A. Kenneth Doe",
-        title : "Rev.",
-        middle : "A. Kenneth",
-        first : "John",
-        last : "Doe"
+        "name" : "Rev. John A. Kenneth Doe",
+        "title" : "Rev.",
+        "middle" : "A. Kenneth",
+        "first" : "John",
+        "last" : "Doe"
     },
     "125" : {
-        name : "Rev John A. Kenneth Doe",
-        title : "Rev",
-        middle : "A. Kenneth",
-        first : "John",
-        last : "Doe"
+        "name" : "Rev John A. Kenneth Doe",
+        "title" : "Rev",
+        "middle" : "A. Kenneth",
+        "first" : "John",
+        "last" : "Doe"
     },
     "126" : {
-        name : "Doe, Rev. John A. Jr.",
-        title : "Rev.",
-        first : "John",
-        last : "Doe",
-        middle : "A.",
-        suffix : "Jr."
+        "name" : "Doe, Rev. John A. Jr.",
+        "title" : "Rev.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A.",
+        "suffix" : "Jr."
     },
     "127" : {
-        name : "Buca di Beppo",
-        first : "Buca",
-        last : "di Beppo"
+        "name" : "Buca di Beppo",
+        "first" : "Buca",
+        "last" : "di Beppo"
     },
     "_le_as_last_name" : {
-        name : "Yin Le",
-        first : "Yin",
-        last : "Le"
+        "name" : "Yin Le",
+        "first" : "Yin",
+        "last" : "Le"
     },
     "_le_as_last_name_with_middle_initial" : {
-        name : "Yin a Le",
-        first : "Yin",
-        middle : "a",
-        last : "Le"
+        "name" : "Yin a Le",
+        "first" : "Yin",
+        "middle" : "a",
+        "last" : "Le"
     },
     "_conjunction_in_an_address_with_a_title" : {
-        name : "His Excellency Lord Duncan",
-        title : "His Excellency Lord",
-        last : "Duncan"
+        "name" : "His Excellency Lord Duncan",
+        "title" : "His Excellency Lord",
+        "last" : "Duncan"
     },
     "_nickname_in_parenthesis" : {
-        name : "Benjamin (Ben) Franklin",
-        first : "Benjamin",
-        middle : "",
-        last : "Franklin",
-        nickname : "Ben"
+        "name" : "Benjamin (Ben) Franklin",
+        "first" : "Benjamin",
+        "middle" : "",
+        "last" : "Franklin",
+        "nickname" : "Ben"
     },
     "_nickname_in_parenthesis_with_comma" : {
-        name : "Franklin, Benjamin (Ben)",
-        first : "Benjamin",
-        middle : "",
-        last : "Franklin",
-        nickname : "Ben"
+        "name" : "Franklin, Benjamin (Ben)",
+        "first" : "Benjamin",
+        "middle" : "",
+        "last" : "Franklin",
+        "nickname" : "Ben"
     },
     "_nickname_in_parenthesis_with_comma_and_suffix" : {
-        name : "Franklin, Benjamin (Ben), Jr.",
-        first : "Benjamin",
-        middle : "",
-        last : "Franklin",
-        suffix : "Jr.",
-        nickname : "Ben"
+        "name" : "Franklin, Benjamin (Ben), Jr.",
+        "first" : "Benjamin",
+        "middle" : "",
+        "last" : "Franklin",
+        "suffix" : "Jr.",
+        "nickname" : "Ben"
     },
     "_nickname_in_double_quotes" : {
-        name : "Benjamin \"Ben\" Franklin",
-        first : "Benjamin",
-        middle : "",
-        last : "Franklin",
-        nickname : "Ben"
+        "name" : "Benjamin \"Ben\" Franklin",
+        "first" : "Benjamin",
+        "middle" : "",
+        "last" : "Franklin",
+        "nickname" : "Ben"
     },
     "_single_quotes_on_first_name_not_treated_as_nickname" : {
-        name : "Brian O'connor",
-        first : "Brian",
-        middle : "",
-        last : "O'connor",
-        nickname : ""
+        "name" : "Brian O'connor",
+        "first" : "Brian",
+        "middle" : "",
+        "last" : "O'connor",
+        "nickname" : ""
     },
     "_single_quotes_on_both_name_not_treated_as_nickname" : {
-        name : "La'tanya O'connor",
-        first : "La'tanya",
-        middle : "",
-        last : "O'connor",
-        nickname : ""
+        "name" : "La'tanya O'connor",
+        "first" : "La'tanya",
+        "middle" : "",
+        "last" : "O'connor",
+        "nickname" : ""
     },
     "_single_quotes_on_end_of_last_name_not_treated_as_nickname" : {
-        name : "Mari' Aube'",
-        first : "Mari'",
-        middle : "",
-        last : "Aube'",
-        nickname : ""
+        "name" : "Mari' Aube'",
+        "first" : "Mari'",
+        "middle" : "",
+        "last" : "Aube'",
+        "nickname" : ""
     },
     "_parenthesis_are_removed2" : {
-        name : "John Jones (Google Docs), Jr. (Unknown)",
-        first : "John",
-        last : "Jones",
-        suffix : "Jr."
+        "name" : "John Jones (Google Docs), Jr. (Unknown)",
+        "first" : "John",
+        "last" : "Jones",
+        "suffix" : "Jr."
     },
     "_prefix" : {
-        name : "Juan del Sur",
-        first : "Juan",
-        last : "del Sur"
+        "name" : "Juan del Sur",
+        "first" : "Juan",
+        "last" : "del Sur"
     },
     "_prefix_with_period" : {
-        name : "Jill St. John",
-        first : "Jill",
-        last : "St. John"
+        "name" : "Jill St. John",
+        "first" : "Jill",
+        "last" : "St. John"
     },
     "_prefix_before_two_part_last_name" : {
-        name : "pennie von bergen wessels",
-        first : "pennie",
-        last : "von bergen wessels"
+        "name" : "pennie von bergen wessels",
+        "first" : "pennie",
+        "last" : "von bergen wessels"
     },
     "_prefix_before_two_part_last_name_with_suffix" : {
-        name : "pennie von bergen wessels III",
-        first : "pennie",
-        last : "von bergen wessels",
-        suffix : "III"
+        "name" : "pennie von bergen wessels III",
+        "first" : "pennie",
+        "last" : "von bergen wessels",
+        "suffix" : "III"
     },
     "_two_part_last_name_with_suffix_comma" : {
-        name : "pennie von bergen wessels, III",
-        first : "pennie",
-        last : "von bergen wessels",
-        suffix : "III"
+        "name" : "pennie von bergen wessels, III",
+        "first" : "pennie",
+        "last" : "von bergen wessels",
+        "suffix" : "III"
     },
     "_two_part_last_name_with_suffix" : {
-        name : "von bergen wessels, pennie III",
-        first : "pennie",
-        last : "von bergen wessels",
-        suffix : "III"
+        "name" : "von bergen wessels, pennie III",
+        "first" : "pennie",
+        "last" : "von bergen wessels",
+        "suffix" : "III"
     },
     "_suffix" : {
-        name : "Joe Franklin Jr",
-        first : "Joe",
-        last : "Franklin",
-        suffix : "Jr"
+        "name" : "Joe Franklin Jr",
+        "first" : "Joe",
+        "last" : "Franklin",
+        "suffix" : "Jr"
     },
     "_suffix_with_periods" : {
-        name : "Joe Dentist D.D.S.",
-        first : "Joe",
-        last : "Dentist",
-        suffix : "D.D.S."
+        "name" : "Joe Dentist D.D.S.",
+        "first" : "Joe",
+        "last" : "Dentist",
+        "suffix" : "D.D.S."
     },
     "_two_suffixes_suffix_comma_format" : {
-        name : "Franklin Washington, Jr. MD",
-        first : "Franklin",
-        last : "Washington",
-        suffix : "Jr. MD"
+        "name" : "Franklin Washington, Jr. MD",
+        "first" : "Franklin",
+        "last" : "Washington",
+        "suffix" : "Jr. MD"
     },
     "_suffix_containing_periods" : {
-        name : "Kenneth Clarke Q.C.",
-        first : "Kenneth",
-        last : "Clarke",
-        suffix : "Q.C."
+        "name" : "Kenneth Clarke Q.C.",
+        "first" : "Kenneth",
+        "last" : "Clarke",
+        "suffix" : "Q.C."
     },
     "_suffix_containing_periods_lastname_comma_format" : {
-        name : "Clarke, Kenneth, Q.C. M.P.",
-        first : "Kenneth",
-        last : "Clarke",
-        suffix : "Q.C. M.P."
+        "name" : "Clarke, Kenneth, Q.C. M.P.",
+        "first" : "Kenneth",
+        "last" : "Clarke",
+        "suffix" : "Q.C. M.P."
     },
     "_suffix_containing_periods_suffix_comma_format" : {
-        name : "Kenneth Clarke Q.C., M.P.",
-        first : "Kenneth",
-        last : "Clarke",
-        suffix : "Q.C., M.P."
+        "name" : "Kenneth Clarke Q.C., M.P.",
+        "first" : "Kenneth",
+        "last" : "Clarke",
+        "suffix" : "Q.C., M.P."
     },
     "_suffix_with_single_comma_format" : {
-        name : "John Doe jr., MD",
-        first : "John",
-        last : "Doe",
-        suffix : "jr., MD"
+        "name" : "John Doe jr., MD",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "jr., MD"
     },
     "_suffix_with_double_comma_format" : {
-        name : "Doe, John jr., MD",
-        first : "John",
-        last : "Doe",
-        suffix : "jr., MD"
+        "name" : "Doe, John jr., MD",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "jr., MD"
     },
     "_potential_suffix_that_is_also_last_name" : {
-        name : "Jack Ma",
-        first : "Jack",
-        last : "Ma"
+        "name" : "Jack Ma",
+        "first" : "Jack",
+        "last" : "Ma"
     },
     "_potential_suffix_that_is_also_last_name_comma" : {
-        name : "Ma, Jack",
-        first : "Jack",
-        last : "Ma"
+        "name" : "Ma, Jack",
+        "first" : "Jack",
+        "last" : "Ma"
     },
     "_potential_suffix_that_is_also_first_name_comma" : {
-        name : "Johnson, Bart",
-        first : "Bart",
-        last : "Johnson"
+        "name" : "Johnson, Bart",
+        "first" : "Bart",
+        "last" : "Johnson"
     },
     "_potential_suffix_that_is_also_last_name_with_suffix" : {
-        name : "Jack Ma Jr",
-        first : "Jack",
-        last : "Ma",
-        suffix : "Jr"
+        "name" : "Jack Ma Jr",
+        "first" : "Jack",
+        "last" : "Ma",
+        "suffix" : "Jr"
     },
     "_potential_suffix_that_is_also_last_name_with_suffix_comma" : {
-        name : "Ma III, Jack Jr",
-        first : "Jack",
-        last : "Ma",
-        suffix : "III, Jr"
+        "name" : "Ma III, Jack Jr",
+        "first" : "Jack",
+        "last" : "Ma",
+        "suffix" : "III, Jr"
     },
     "_suffix_with_periods" : {
-        name : "John Doe Msc.Ed.",
-        first : "John",
-        last : "Doe",
-        suffix : "Msc.Ed."
+        "name" : "John Doe Msc.Ed.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "Msc.Ed."
     },
     "_suffix_with_periods_with_comma" : {
-        name : "John Doe, Msc.Ed.",
-        first : "John",
-        last : "Doe",
-        suffix : "Msc.Ed."
+        "name" : "John Doe, Msc.Ed.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "Msc.Ed."
     },
     "_suffix_with_periods_with_lastname_comma" : {
-        name : "Doe, John Msc.Ed.",
-        first : "John",
-        last : "Doe",
-        suffix : "Msc.Ed."
+        "name" : "Doe, John Msc.Ed.",
+        "first" : "John",
+        "last" : "Doe",
+        "suffix" : "Msc.Ed."
     },
     "_last_name_is_also_title" : {
-        name : "Amy E Maid",
-        first : "Amy",
-        middle : "E",
-        last : "Maid"
+        "name" : "Amy E Maid",
+        "first" : "Amy",
+        "middle" : "E",
+        "last" : "Maid"
     },
     "_last_name_is_also_title_no_comma" : {
-        name : "Dr. Martin Luther King Jr.",
-        title : "Dr.",
-        first : "Martin",
-        middle : "Luther",
-        last : "King",
-        suffix : "Jr."
+        "name" : "Dr. Martin Luther King Jr.",
+        "title" : "Dr.",
+        "first" : "Martin",
+        "middle" : "Luther",
+        "last" : "King",
+        "suffix" : "Jr."
     },
     "_last_name_is_also_title_with_comma" : {
-        name : "Duke Martin Luther King, Jr.",
-        title : "Duke",
-        first : "Martin",
-        middle : "Luther",
-        last : "King",
-        suffix : "Jr."
+        "name" : "Duke Martin Luther King, Jr.",
+        "title" : "Duke",
+        "first" : "Martin",
+        "middle" : "Luther",
+        "last" : "King",
+        "suffix" : "Jr."
     },
     "_last_name_is_also_title3" : {
-        name : "John King",
-        first : "John",
-        last : "King"
+        "name" : "John King",
+        "first" : "John",
+        "last" : "King"
     },
     "_title_with_conjunction" : {
-        name : "Secretary of State Hillary Clinton",
-        title : "Secretary of State",
-        first : "Hillary",
-        last : "Clinton"
+        "name" : "Secretary of State Hillary Clinton",
+        "title" : "Secretary of State",
+        "first" : "Hillary",
+        "last" : "Clinton"
     },
     "_compound_title_with_conjunction" : {
-        name : "Cardinal Secretary of State Hillary Clinton",
-        title : "Cardinal Secretary of State",
-        first : "Hillary",
-        last : "Clinton"
+        "name" : "Cardinal Secretary of State Hillary Clinton",
+        "title" : "Cardinal Secretary of State",
+        "first" : "Hillary",
+        "last" : "Clinton"
     },
     "_title_is_title" : {
-        name : "Coach",
-        title : "Coach"
+        "name" : "Coach",
+        "title" : "Coach"
     },
     "_conflict_with_chained_title_first_name_initial" : {
-        name : "U. S. Grant",
-        first : "U.",
-        middle : "S.",
-        last : "Grant"
+        "name" : "U. S. Grant",
+        "first" : "U.",
+        "middle" : "S.",
+        "last" : "Grant"
     },
     "_chained_title_first_name_initial" : {
-        name : "US Magistrate Judge T Michael Putnam",
-        title : "US Magistrate Judge",
-        first : "T",
-        middle : "Michael",
-        last : "Putnam"
+        "name" : "US Magistrate Judge T Michael Putnam",
+        "title" : "US Magistrate Judge",
+        "first" : "T",
+        "middle" : "Michael",
+        "last" : "Putnam"
     },
     "_chained_hyphenated_title" : {
-        name : "US Magistrate-Judge Elizabeth E Campbell",
-        title : "US Magistrate-Judge",
-        first : "Elizabeth",
-        middle : "E",
-        last : "Campbell"
+        "name" : "US Magistrate-Judge Elizabeth E Campbell",
+        "title" : "US Magistrate-Judge",
+        "first" : "Elizabeth",
+        "middle" : "E",
+        "last" : "Campbell"
     },
     "_chained_hyphenated_title_with_comma_suffix" : {
-        name : "Mag-Judge Harwell G Davis, III",
-        title : "Mag-Judge",
-        first : "Harwell",
-        middle : "G",
-        last : "Davis",
-        suffix : "III"
+        "name" : "Mag-Judge Harwell G Davis, III",
+        "title" : "Mag-Judge",
+        "first" : "Harwell",
+        "middle" : "G",
+        "last" : "Davis",
+        "suffix" : "III"
     },
     "_title_starts_with_conjunction" : {
-        name : "The Rt Hon John Jones",
-        title : "The Rt Hon",
-        first : "John",
-        last : "Jones"
+        "name" : "The Rt Hon John Jones",
+        "title" : "The Rt Hon",
+        "first" : "John",
+        "last" : "Jones"
     },
     "_conjunction_before_title" : {
-        name : 'The Lord of the Universe',
-        title : "The Lord of the Universe"
+        "name" : 'The Lord of the Universe',
+        "title" : "The Lord of the Universe"
     },
     "_double_conjunction_on_title" : {
-        name : 'Lord of the Universe',
-        title : "Lord of the Universe"
+        "name" : 'Lord of the Universe',
+        "title" : "Lord of the Universe"
     },
     "_triple_conjunction_on_title" : {
-        name : 'Lord and of the Universe',
-        title : "Lord and of the Universe"
+        "name" : 'Lord and of the Universe',
+        "title" : "Lord and of the Universe"
     },
     "_multiple_conjunctions_on_multiple_titles" : {
-        name : 'Lord of the Universe and Associate Supreme Queen of the World Lisa Simpson',
-        title : "Lord of the Universe and Associate Supreme Queen of the World",
-        first : "Lisa",
-        last : "Simpson"
+        "name" : 'Lord of the Universe and Associate Supreme Queen of the World Lisa Simpson',
+        "title" : "Lord of the Universe and Associate Supreme Queen of the World",
+        "first" : "Lisa",
+        "last" : "Simpson"
     },
     "_title_with_last_initial_is_suffix" : {
-        name : "King John V.",
-        title : "King",
-        first : "John",
-        last : "V."
+        "name" : "King John V.",
+        "title" : "King",
+        "first" : "John",
+        "last" : "V."
     },
     "_two_title_parts_separated_by_periods" : {
-        name : "Lt.Gen. John A. Kenneth Doe IV",
-        title : "Lt.Gen.",
-        first : "John",
-        last : "Doe",
-        middle : "A. Kenneth",
-        suffix : "IV"
+        "name" : "Lt.Gen. John A. Kenneth Doe IV",
+        "title" : "Lt.Gen.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A. Kenneth",
+        "suffix" : "IV"
     },
     "_two_part_title" : {
-        name : "Lt. Gen. John A. Kenneth Doe IV",
-        title : "Lt. Gen.",
-        first : "John",
-        last : "Doe",
-        middle : "A. Kenneth",
-        suffix : "IV"
+        "name" : "Lt. Gen. John A. Kenneth Doe IV",
+        "title" : "Lt. Gen.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A. Kenneth",
+        "suffix" : "IV"
     },
     "_two_part_title_with_lastname_comma" : {
-        name : "Doe, Lt. Gen. John A. Kenneth IV",
-        title : "Lt. Gen.",
-        first : "John",
-        last : "Doe",
-        middle : "A. Kenneth",
-        suffix : "IV"
+        "name" : "Doe, Lt. Gen. John A. Kenneth IV",
+        "title" : "Lt. Gen.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A. Kenneth",
+        "suffix" : "IV"
     },
     "_two_part_title_with_suffix_comma" : {
-        name : "Lt. Gen. John A. Kenneth Doe, Jr.",
-        title : "Lt. Gen.",
-        first : "John",
-        last : "Doe",
-        middle : "A. Kenneth",
-        suffix : "Jr."
+        "name" : "Lt. Gen. John A. Kenneth Doe, Jr.",
+        "title" : "Lt. Gen.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A. Kenneth",
+        "suffix" : "Jr."
     },
     "_possible_conflict_with_middle_initial_that_could_be_suffix" : {
-        name : "Doe, Rev. John V, Jr.",
-        title : "Rev.",
-        first : "John",
-        last : "Doe",
-        middle : "V",
-        suffix : "Jr."
+        "name" : "Doe, Rev. John V, Jr.",
+        "title" : "Rev.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "V",
+        "suffix" : "Jr."
     },
     "_possible_conflict_with_suffix_that_could_be_initial" : {
-        name : "Doe, Rev. John A., V, Jr.",
-        title : "Rev.",
-        first : "John",
-        last : "Doe",
-        middle : "A.",
-        suffix : "V, Jr."
+        "name" : "Doe, Rev. John A., V, Jr.",
+        "title" : "Rev.",
+        "first" : "John",
+        "last" : "Doe",
+        "middle" : "A.",
+        "suffix" : "V, Jr."
     },
     "_ben_as_first_name" : {
-        name : "Ben Johnson",
-        first : "Ben",
-        last : "Johnson"
+        "name" : "Ben Johnson",
+        "first" : "Ben",
+        "last" : "Johnson"
     },
     "_ben_as_first_name_with_middle_name" : {
-        name : "Ben Alex Johnson",
-        first : "Ben",
-        middle : "Alex",
-        last : "Johnson"
+        "name" : "Ben Alex Johnson",
+        "first" : "Ben",
+        "middle" : "Alex",
+        "last" : "Johnson"
     },
     "_ben_as_middle_name" : {
-        name : "Alex Ben Johnson",
-        first : "Alex",
-        middle : "Ben",
-        last : "Johnson"
+        "name" : "Alex Ben Johnson",
+        "first" : "Alex",
+        "middle" : "Ben",
+        "last" : "Johnson"
     },
     "_last_name_also_prefix" : {
-        name : "Jane Doctor",
-        first : "Jane",
-        last : "Doctor"
+        "name" : "Jane Doctor",
+        "first" : "Jane",
+        "last" : "Doctor"
     },
     "_title_with_periods" : {
-        name : "Lt.Gov. John Doe",
-        title : "Lt.Gov.",
-        first : "John",
-        last : "Doe"
+        "name" : "Lt.Gov. John Doe",
+        "title" : "Lt.Gov.",
+        "first" : "John",
+        "last" : "Doe"
     },
     "_title_with_periods_lastname_comma" : {
-        name : "Doe, Lt.Gov. John",
-        title : "Lt.Gov.",
-        first : "John",
-        last : "Doe"
+        "name" : "Doe, Lt.Gov. John",
+        "title" : "Lt.Gov.",
+        "first" : "John",
+        "last" : "Doe"
     }
 }

--- a/testnames.json
+++ b/testnames.json
@@ -1,0 +1,1399 @@
+{
+    "_utf8" : {
+        name : "de la Véña, Jüan",
+        first : "Jüan",
+        last : "de la Véña"
+    },
+    "_escaped_utf8_bytes" : {
+        name : b'B\xc3\xb6ck, Gerald',
+        first : "Gerald",
+        last : "Böck"
+    },
+    "_conjunction_names" : {
+        name : "johnny y",
+        first : "johnny",
+        last : "y"
+    },
+    "_prefix_names" : {
+        name : "vai la",
+        first : "vai",
+        last : "la"
+    },
+    "_blank_name" : {
+        name = "",
+        first : "",
+        last : ""
+    },
+    "_first_name" : {
+        name : "Andrew",
+        first : "Andrew"
+    },
+    "_assume_title_and_one_other_name_is_last_name" : {
+        name : "Rev Andrews",
+        title : "Rev",
+        last : "Andrews"
+    },
+    "_suffix_in_lastname_part_of_lastname_comma_format" : {
+        name : "Smith Jr., John",
+        last : "Smith",
+        first : "John",
+        suffix : "Jr."
+    },
+    "_sir_exception_to_first_name_rule" : {
+        name : "Sir Gerald",
+        title : "Sir",
+        first : "Gerald"
+    },
+    "_king_exception_to_first_name_rule" : {
+        name : "King Henry",
+        title : "King",
+        first : "Henry"
+    },
+    "_queen_exception_to_first_name_rule" : {
+        name : "Queen Elizabeth",
+        title : "Queen",
+        first : "Elizabeth"
+    },
+    "_dame_exception_to_first_name_rule" : {
+        name : "Dame Mary",
+        title : "Dame",
+        first : "Mary"
+    },
+    "_first_name_is_not_prefix_if_only_two_parts_comma" : {
+        name : "Nguyen, Van",
+        first : "Van",
+        last : "Nguyen"
+    },
+    "1" : {
+        name : "John Doe",
+        first : "John",
+        last : "Doe"
+    },
+    "2" : {
+        name : "John Doe, Jr.",
+        first : "John",
+        last : "Doe",
+        suffix : "Jr."
+    },
+    "3" : {
+        name : "John Doe III",
+        first : "John",
+        last : "Doe",
+        suffix : "III"
+    },
+    "4" : {
+        name : "Doe, John",
+        first : "John",
+        last : "Doe"
+    },
+    "5" : {
+        name : "Doe, John, Jr.",
+        first : "John",
+        last : "Doe",
+        suffix : "Jr."
+    },
+    "6" : {
+        name : "Doe, John III",
+        first : "John",
+        last : "Doe",
+        suffix : "III"
+    },
+    "7" : {
+        name : "John A. Doe",
+        first : "John",
+        last : "Doe",
+        middle : "A."
+    },
+    "8" : {
+        name : "John A. Doe, Jr",
+        first : "John",
+        last : "Doe",
+        middle : "A.",
+        suffix : "Jr"
+    },
+    "9" : {
+        name : "John A. Doe III",
+        first : "John",
+        last : "Doe",
+        middle : "A.",
+        suffix : "III"
+    },
+    "10" : {
+        name : "Doe, John A.",
+        first : "John",
+        last : "Doe",
+        middle : "A."
+    },
+    "11" : {
+        name : "Doe, John A., Jr.",
+        first : "John",
+        last : "Doe",
+        middle : "A.",
+        suffix : "Jr."
+    },
+    "12" : {
+        name : "Doe, John A., III",
+        first : "John",
+        last : "Doe",
+        middle : "A.",
+        suffix : "III"
+    },
+    "13" : {
+        name : "John A. Kenneth Doe",
+        first : "John",
+        last : "Doe",
+        middle : "A. Kenneth"
+    },
+    "14" : {
+        name : "John A. Kenneth Doe, Jr.",
+        first : "John",
+        last : "Doe",
+        middle : "A. Kenneth",
+        suffix : "Jr."
+    },
+    "15" : {
+        name : "John A. Kenneth Doe III",
+        first : "John",
+        last : "Doe",
+        middle : "A. Kenneth",
+        suffix : "III"
+    },
+    "16" : {
+        name : "Doe, John. A. Kenneth",
+        first : "John.",
+        last : "Doe",
+        middle : "A. Kenneth"
+    },
+    "17" : {
+        name : "Doe, John. A. Kenneth, Jr.",
+        first : "John.",
+        last : "Doe",
+        middle : "A. Kenneth",
+        suffix : "Jr."
+    },
+    "18" : {
+        name : "Doe, John. A. Kenneth III",
+        first : "John.",
+        last : "Doe",
+        middle : "A. Kenneth",
+        suffix : "III"
+    },
+    "19" : {
+        name : "Dr. John Doe",
+        first : "John",
+        last : "Doe",
+        title : "Dr."
+    },
+    "20" : {
+        name : "Dr. John Doe, Jr.",
+        title : "Dr.",
+        first : "John",
+        last : "Doe",
+        suffix : "Jr."
+    },
+    "21" : {
+        name : "Dr. John Doe III",
+        title : "Dr.",
+        first : "John",
+        last : "Doe",
+        suffix : "III"
+    },
+    "22" : {
+        name : "Doe, Dr. John",
+        title : "Dr.",
+        first : "John",
+        last : "Doe"
+    },
+    "23" : {
+        name : "Doe, Dr. John, Jr.",
+        title : "Dr.",
+        first : "John",
+        last : "Doe",
+        suffix : "Jr."
+    },
+    "24" : {
+        name : "Doe, Dr. John III",
+        title : "Dr.",
+        first : "John",
+        last : "Doe",
+        suffix : "III"
+    },
+    "25" : {
+        name : "Dr. John A. Doe",
+        title : "Dr.",
+        first : "John",
+        last : "Doe",
+        middle : "A."
+    },
+    "26" : {
+        name : "Dr. John A. Doe, Jr.",
+        title : "Dr.",
+        first : "John",
+        last : "Doe",
+        middle : "A.",
+        suffix : "Jr."
+    },
+    "27" : {
+        name : "Dr. John A. Doe III",
+        title : "Dr.",
+        first : "John",
+        last : "Doe",
+        middle : "A.",
+        suffix : "III"
+    },
+    "28" : {
+        name : "Doe, Dr. John A.",
+        title : "Dr.",
+        first : "John",
+        last : "Doe",
+        middle : "A."
+    },
+    "29" : {
+        name : "Doe, Dr. John A. Jr.",
+        title : "Dr.",
+        first : "John",
+        last : "Doe",
+        middle : "A.",
+        suffix : "Jr."
+    },
+    "30" : {
+        name : "Doe, Dr. John A. III",
+        title : "Dr.",
+        middle : "A.",
+        first : "John",
+        last : "Doe",
+        suffix : "III"
+    },
+    "31" : {
+        name : "Dr. John A. Kenneth Doe",
+        title : "Dr.",
+        middle : "A. Kenneth",
+        first : "John",
+        last : "Doe"
+    },
+    "32" : {
+        name : "Dr. John A. Kenneth Doe, Jr.",
+        title : "Dr.",
+        middle : "A. Kenneth",
+        first : "John",
+        last : "Doe",
+        suffix : "Jr."
+    },
+    "33" : {
+        name : "Al Arnold Gore, Jr.",
+        middle : "Arnold",
+        first : "Al",
+        last : "Gore",
+        suffix : "Jr."
+    },
+    "34" : {
+        name : "Dr. John A. Kenneth Doe III",
+        title : "Dr.",
+        middle : "A. Kenneth",
+        first : "John",
+        last : "Doe",
+        suffix : "III"
+    },
+    "35" : {
+        name : "Doe, Dr. John A. Kenneth",
+        title : "Dr.",
+        middle : "A. Kenneth",
+        first : "John",
+        last : "Doe"
+    },
+    "36" : {
+        name : "Doe, Dr. John A. Kenneth Jr.",
+        title : "Dr.",
+        middle : "A. Kenneth",
+        first : "John",
+        last : "Doe",
+        suffix : "Jr."
+    },
+    "37" : {
+        name : "Doe, Dr. John A. Kenneth III",
+        title : "Dr.",
+        middle : "A. Kenneth",
+        first : "John",
+        last : "Doe",
+        suffix : "III"
+    },
+    "38" : {
+        name : "Juan de la Vega",
+        first : "Juan",
+        last : "de la Vega"
+    },
+    "39" : {
+        name : "Juan de la Vega, Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        suffix : "Jr."
+    },
+    "40" : {
+        name : "Juan de la Vega III",
+        first : "Juan",
+        last : "de la Vega",
+        suffix : "III"
+    },
+    "41" : {
+        name : "de la Vega, Juan",
+        first : "Juan",
+        last : "de la Vega"
+    },
+    "42" : {
+        name : "de la Vega, Juan, Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        suffix : "Jr."
+    },
+    "43" : {
+        name : "de la Vega, Juan III",
+        first : "Juan",
+        last : "de la Vega",
+        suffix : "III"
+    },
+    "44" : {
+        name : "Juan Velasquez y Garcia",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "45" : {
+        name : "Juan Velasquez y Garcia, Jr.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "46" : {
+        name : "Juan Velasquez y Garcia III",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "47" : {
+        name : "Velasquez y Garcia, Juan",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "48" : {
+        name : "Velasquez y Garcia, Juan, Jr.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "49" : {
+        name : "Velasquez y Garcia, Juan III",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "50" : {
+        name : "Dr. Juan de la Vega",
+        title : "Dr.",
+        first : "Juan",
+        last : "de la Vega"
+    },
+    "51" : {
+        name : "Dr. Juan de la Vega, Jr.",
+        title : "Dr.",
+        first : "Juan",
+        last : "de la Vega",
+        suffix : "Jr."
+    },
+    "52" : {
+        name : "Dr. Juan de la Vega III",
+        title : "Dr.",
+        first : "Juan",
+        last : "de la Vega",
+        suffix : "III"
+    },
+    "53" : {
+        name : "de la Vega, Dr. Juan",
+        title : "Dr.",
+        first : "Juan",
+        last : "de la Vega"
+    },
+    "54" : {
+        name : "de la Vega, Dr. Juan, Jr.",
+        title : "Dr.",
+        first : "Juan",
+        last : "de la Vega",
+        suffix : "Jr."
+    },
+    "55" : {
+        name : "de la Vega, Dr. Juan III",
+        title : "Dr.",
+        first : "Juan",
+        last : "de la Vega",
+        suffix : "III"
+    },
+    "56" : {
+        name : "Dr. Juan Velasquez y Garcia",
+        title : "Dr.",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "57" : {
+        name : "Dr. Juan Velasquez y Garcia, Jr.",
+        title : "Dr.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "58" : {
+        name : "Dr. Juan Velasquez y Garcia III",
+        title : "Dr.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "59" : {
+        name : "Velasquez y Garcia, Dr. Juan",
+        title : "Dr.",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "60" : {
+        name : "Velasquez y Garcia, Dr. Juan, Jr.",
+        title : "Dr.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "61" : {
+        name : "Velasquez y Garcia, Dr. Juan III",
+        title : "Dr.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "62" : {
+        name : "Juan Q. de la Vega",
+        first : "Juan",
+        middle : "Q.",
+        last : "de la Vega"
+    },
+    "63" : {
+        name : "Juan Q. de la Vega, Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q.",
+        suffix : "Jr."
+    },
+    "64" : {
+        name : "Juan Q. de la Vega III",
+        first : "Juan",
+        middle : "Q.",
+        last : "de la Vega",
+        suffix : "III"
+    },
+    "65" : {
+        name : "de la Vega, Juan Q.",
+        first : "Juan",
+        middle : "Q.",
+        last : "de la Vega"
+    },
+    "66" : {
+        name : "de la Vega, Juan Q., Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q.",
+        suffix : "Jr."
+    },
+    "67" : {
+        name : "de la Vega, Juan Q. III",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q.",
+        suffix : "III"
+    },
+    "68" : {
+        name : "Juan Q. Velasquez y Garcia",
+        middle : "Q.",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "69" : {
+        name : "Juan Q. Velasquez y Garcia, Jr.",
+        middle : "Q.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "70" : {
+        name : "Juan Q. Velasquez y Garcia III",
+        middle : "Q.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "71" : {
+        name : "Velasquez y Garcia, Juan Q.",
+        middle : "Q.",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "72" : {
+        name : "Velasquez y Garcia, Juan Q., Jr.",
+        middle : "Q.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "73" : {
+        name : "Velasquez y Garcia, Juan Q. III",
+        middle : "Q.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "74" : {
+        name : "Dr. Juan Q. de la Vega",
+        title : "Dr.",
+        first : "Juan",
+        middle : "Q.",
+        last : "de la Vega"
+    },
+    "75" : {
+        name : "Dr. Juan Q. de la Vega, Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q.",
+        title : "Dr.",
+        suffix : "Jr."
+    },
+    "76" : {
+        name : "Dr. Juan Q. de la Vega III",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q.",
+        title : "Dr.",
+        suffix : "III"
+    },
+    "77" : {
+        name : "de la Vega, Dr. Juan Q.",
+        first : "Juan",
+        middle : "Q.",
+        last : "de la Vega",
+        title : "Dr."
+    },
+    "78" : {
+        name : "de la Vega, Dr. Juan Q., Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q.",
+        suffix : "Jr.",
+        title : "Dr."
+    },
+    "79" : {
+        name : "de la Vega, Dr. Juan Q. III",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q.",
+        suffix : "III",
+        title : "Dr."
+    },
+    "80" : {
+        name : "Dr. Juan Q. Velasquez y Garcia",
+        title : "Dr.",
+        middle : "Q.",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "81" : {
+        name : "Dr. Juan Q. Velasquez y Garcia, Jr.",
+        title : "Dr.",
+        middle : "Q.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "82" : {
+        name : "Dr. Juan Q. Velasquez y Garcia III",
+        middle : "Q.",
+        title : "Dr.",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "83" : {
+        name : "Velasquez y Garcia, Dr. Juan Q.",
+        title : "Dr.",
+        middle : "Q.",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "84" : {
+        name : "Velasquez y Garcia, Dr. Juan Q., Jr.",
+        middle : "Q.",
+        first : "Juan",
+        title : "Dr.",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "85" : {
+        name : "Velasquez y Garcia, Dr. Juan Q. III",
+        middle : "Q.",
+        first : "Juan",
+        title : "Dr.",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "86" : {
+        name : "Juan Q. Xavier de la Vega",
+        first : "Juan",
+        middle : "Q. Xavier",
+        last : "de la Vega"
+    },
+    "87" : {
+        name : "Juan Q. Xavier de la Vega, Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q. Xavier",
+        suffix : "Jr."
+    },
+    "88" : {
+        name : "Juan Q. Xavier de la Vega III",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q. Xavier",
+        suffix : "III"
+    },
+    "89" : {
+        name : "de la Vega, Juan Q. Xavier",
+        first : "Juan",
+        middle : "Q. Xavier",
+        last : "de la Vega"
+    },
+    "90" : {
+        name : "de la Vega, Juan Q. Xavier, Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q. Xavier",
+        suffix : "Jr."
+    },
+    "91" : {
+        name : "de la Vega, Juan Q. Xavier III",
+        first : "Juan",
+        last : "de la Vega",
+        middle : "Q. Xavier",
+        suffix : "III"
+    },
+    "92" : {
+        name : "Dr. Juan Q. Xavier de la Vega",
+        first : "Juan",
+        middle : "Q. Xavier",
+        title : "Dr.",
+        last : "de la Vega"
+    },
+    "93" : {
+        name : "Dr. Juan Q. Xavier de la Vega, Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        title : "Dr.",
+        middle : "Q. Xavier",
+        suffix : "Jr."
+    },
+    "94" : {
+        name : "Dr. Juan Q. Xavier de la Vega III",
+        first : "Juan",
+        last : "de la Vega",
+        title : "Dr.",
+        middle : "Q. Xavier",
+        suffix : "III"
+    },
+    "95" : {
+        name : "de la Vega, Dr. Juan Q. Xavier",
+        first : "Juan",
+        title : "Dr.",
+        middle : "Q. Xavier",
+        last : "de la Vega"
+    },
+    "96" : {
+        name : "de la Vega, Dr. Juan Q. Xavier, Jr.",
+        first : "Juan",
+        last : "de la Vega",
+        title : "Dr.",
+        middle : "Q. Xavier",
+        suffix : "Jr."
+    },
+    "97" : {
+        name : "de la Vega, Dr. Juan Q. Xavier III",
+        first : "Juan",
+        title : "Dr.",
+        last : "de la Vega",
+        middle : "Q. Xavier",
+        suffix : "III"
+    },
+    "98" : {
+        name : "Juan Q. Xavier Velasquez y Garcia",
+        middle : "Q. Xavier",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "99" : {
+        name : "Juan Q. Xavier Velasquez y Garcia, Jr.",
+        middle : "Q. Xavier",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "100" : {
+        name : "Juan Q. Xavier Velasquez y Garcia III",
+        middle : "Q. Xavier",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "101" : {
+        name : "Velasquez y Garcia, Juan Q. Xavier",
+        middle : "Q. Xavier",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "102" : {
+        name : "Velasquez y Garcia, Juan Q. Xavier, Jr.",
+        middle : "Q. Xavier",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "103" : {
+        name : "Velasquez y Garcia, Juan Q. Xavier III",
+        middle : "Q. Xavier",
+        first : "Juan",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "104" : {
+        name : "Dr. Juan Q. Xavier Velasquez y Garcia",
+        title : "Dr.",
+        middle : "Q. Xavier",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "105" : {
+        name : "Dr. Juan Q. Xavier Velasquez y Garcia, Jr.",
+        middle : "Q. Xavier",
+        first : "Juan",
+        title : "Dr.",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "106" : {
+        name : "Dr. Juan Q. Xavier Velasquez y Garcia III",
+        middle : "Q. Xavier",
+        first : "Juan",
+        title : "Dr.",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "107" : {
+        name : "Velasquez y Garcia, Dr. Juan Q. Xavier",
+        title : "Dr.",
+        middle : "Q. Xavier",
+        first : "Juan",
+        last : "Velasquez y Garcia"
+    },
+    "108" : {
+        name : "Velasquez y Garcia, Dr. Juan Q. Xavier, Jr.",
+        middle : "Q. Xavier",
+        first : "Juan",
+        title : "Dr.",
+        last : "Velasquez y Garcia",
+        suffix : "Jr."
+    },
+    "109" : {
+        name : "Velasquez y Garcia, Dr. Juan Q. Xavier III",
+        middle : "Q. Xavier",
+        first : "Juan",
+        title : "Dr.",
+        last : "Velasquez y Garcia",
+        suffix : "III"
+    },
+    "110" : {
+        name : "John Doe, CLU, CFP, LUTC",
+        first : "John",
+        last : "Doe",
+        suffix : "CLU, CFP, LUTC"
+    },
+    "111" : {
+        name : "John P. Doe, CLU, CFP, LUTC",
+        first : "John",
+        middle : "P.",
+        last : "Doe",
+        suffix : "CLU, CFP, LUTC"
+    },
+    "112" : {
+        name : "Dr. John P. Doe-Ray, CLU, CFP, LUTC",
+        first : "John",
+        middle : "P.",
+        last : "Doe-Ray",
+        title : "Dr.",
+        suffix : "CLU, CFP, LUTC"
+    },
+    "113" : {
+        name : "Doe-Ray, Dr. John P., CLU, CFP, LUTC",
+        title : "Dr.",
+        middle : "P.",
+        first : "John",
+        last : "Doe-Ray",
+        suffix : "CLU, CFP, LUTC"
+    },
+    "115" : {
+        name : "Hon. Barrington P. Doe-Ray, Jr.",
+        title : "Hon.",
+        middle : "P.",
+        first : "Barrington",
+        last : "Doe-Ray"
+    },
+    "116" : {
+        name : "Doe-Ray, Hon. Barrington P. Jr., CFP, LUTC",
+        title : "Hon.",
+        middle : "P.",
+        first : "Barrington",
+        last : "Doe-Ray",
+        suffix : "Jr., CFP, LUTC"
+    },
+    "117" : {
+        name : "Rt. Hon. Paul E. Mary",
+        title : "Rt. Hon.",
+        first : "Paul",
+        middle : "E.",
+        last : "Mary"
+    },
+    "119" : {
+        name : "Lord God Almighty",
+        title : "Lord",
+        first : "God",
+        last : "Almighty"
+    },
+    "_last_name_with_conjunction" : {
+        name : 'Jose Aznar y Lopez',
+        first : "Jose",
+        last : "Aznar y Lopez"
+    },
+    "_multiple_conjunctions" : {
+        name : "part1 of The part2 of the part3 and part4",
+        first : "part1 of The part2 of the part3 and part4"
+    },
+    "_multiple_conjunctions2" : {
+        name : "part1 of and The part2 of the part3 And part4",
+        first : "part1 of and The part2 of the part3 And part4"
+    },
+    "_ends_with_conjunction" : {
+        name : "Jon Dough and",
+        first : "Jon",
+        last : "Dough and"
+    },
+    "_ends_with_two_conjunctions" : {
+        name : "Jon Dough and of",
+        first : "Jon",
+        last : "Dough and of"
+    },
+    "_starts_with_conjunction" : {
+        name : "and Jon Dough",
+        first : "and Jon",
+        last : "Dough"
+    },
+    "_starts_with_two_conjunctions" : {
+        name : "the and Jon Dough",
+        first : "the and Jon",
+        last : "Dough"
+    },
+    "_uppercase_middle_initial_conflict_with_conjunction" : {
+        name : 'John E Smith',
+        first : "John",
+        middle : "E",
+        last : "Smith"
+    },
+    "_lowercase_middle_initial_with_period_conflict_with_conjunction" : {
+        name : 'john e. smith',
+        first : "john",
+        middle : "e.",
+        last : "smith"
+    },
+    "_lowercase_first_initial_conflict_with_conjunction" : {
+        name : 'e j smith',
+        first : "e",
+        middle : "j",
+        last : "smith"
+    },
+    "_lowercase_middle_initial_conflict_with_conjunction" : {
+        name : 'John e Smith',
+        first : "John",
+        middle : "e",
+        last : "Smith"
+    },
+    "_lowercase_middle_initial_and_suffix_conflict_with_conjunction" : {
+        name : 'John e Smith, III',
+        first : "John",
+        middle : "e",
+        last : "Smith",
+        suffix : "III"
+    },
+    "_lowercase_middle_initial_and_nocomma_suffix_conflict_with_conjunction" : {
+        name : 'John e Smith III',
+        first : "John",
+        middle : "e",
+        last : "Smith",
+        suffix : "III"
+    },
+    "_lowercase_middle_initial_comma_lastname_and_suffix_conflict_with_conjunction" : {
+        name : 'Smith, John e, III, Jr',
+        first : "John",
+        middle : "e",
+        last : "Smith",
+        suffix : "III, Jr"
+    },
+    "_couples_names" : {
+        name : 'John and Jane Smith',
+        first : "John and Jane",
+        last : "Smith"
+    },
+    "_couples_names_with_conjunction_lastname" : {
+        name : 'John and Jane Aznar y Lopez',
+        first : "John and Jane",
+        last : "Aznar y Lopez"
+    },
+    "_couple_titles" : {
+        name : 'Mr. and Mrs. John and Jane Smith',
+        title : "Mr. and Mrs.",
+        first : "John and Jane",
+        last : "Smith"
+    },
+    "_title_with_three_part_name_last_initial_is_suffix_uppercase_no_period" : {
+        name : "King John Alexander V",
+        title : "King",
+        first : "John",
+        last : "Alexander",
+        suffix : "V"
+    },
+    "_four_name_parts_with_suffix_that_could_be_initial_lowercase_no_period" : {
+        name : "larry james edward johnson v",
+        first : "larry",
+        middle : "james edward",
+        last : "johnson",
+        suffix : "v"
+    },
+    "_four_name_parts_with_suffix_that_could_be_initial_uppercase_no_period" : {
+        name : "Larry James Johnson I",
+        first : "Larry",
+        middle : "James",
+        last : "Johnson",
+        suffix : "I"
+    },
+    "_roman_numeral_initials" : {
+        name : "Larry V I",
+        first : "Larry",
+        middle : "V",
+        last : "I",
+        suffix : ""
+    },
+    "124" : {
+        name : "Rev. John A. Kenneth Doe",
+        title : "Rev.",
+        middle : "A. Kenneth",
+        first : "John",
+        last : "Doe"
+    },
+    "125" : {
+        name : "Rev John A. Kenneth Doe",
+        title : "Rev",
+        middle : "A. Kenneth",
+        first : "John",
+        last : "Doe"
+    },
+    "126" : {
+        name : "Doe, Rev. John A. Jr.",
+        title : "Rev.",
+        first : "John",
+        last : "Doe",
+        middle : "A.",
+        suffix : "Jr."
+    },
+    "127" : {
+        name : "Buca di Beppo",
+        first : "Buca",
+        last : "di Beppo"
+    },
+    "_le_as_last_name" : {
+        name : "Yin Le",
+        first : "Yin",
+        last : "Le"
+    },
+    "_le_as_last_name_with_middle_initial" : {
+        name : "Yin a Le",
+        first : "Yin",
+        middle : "a",
+        last : "Le"
+    },
+    "_conjunction_in_an_address_with_a_title" : {
+        name : "His Excellency Lord Duncan",
+        title : "His Excellency Lord",
+        last : "Duncan"
+    },
+    "_nickname_in_parenthesis" : {
+        name : "Benjamin (Ben) Franklin",
+        first : "Benjamin",
+        middle : "",
+        last : "Franklin",
+        nickname : "Ben"
+    },
+    "_nickname_in_parenthesis_with_comma" : {
+        name : "Franklin, Benjamin (Ben)",
+        first : "Benjamin",
+        middle : "",
+        last : "Franklin",
+        nickname : "Ben"
+    },
+    "_nickname_in_parenthesis_with_comma_and_suffix" : {
+        name : "Franklin, Benjamin (Ben), Jr.",
+        first : "Benjamin",
+        middle : "",
+        last : "Franklin",
+        suffix : "Jr.",
+        nickname : "Ben"
+    },
+    "_nickname_in_double_quotes" : {
+        name : "Benjamin \"Ben\" Franklin",
+        first : "Benjamin",
+        middle : "",
+        last : "Franklin",
+        nickname : "Ben"
+    },
+    "_single_quotes_on_first_name_not_treated_as_nickname" : {
+        name : "Brian O'connor",
+        first : "Brian",
+        middle : "",
+        last : "O'connor",
+        nickname : ""
+    },
+    "_single_quotes_on_both_name_not_treated_as_nickname" : {
+        name : "La'tanya O'connor",
+        first : "La'tanya",
+        middle : "",
+        last : "O'connor",
+        nickname : ""
+    },
+    "_single_quotes_on_end_of_last_name_not_treated_as_nickname" : {
+        name : "Mari' Aube'",
+        first : "Mari'",
+        middle : "",
+        last : "Aube'",
+        nickname : ""
+    },
+    "_parenthesis_are_removed2" : {
+        name : "John Jones (Google Docs), Jr. (Unknown)",
+        first : "John",
+        last : "Jones",
+        suffix : "Jr."
+    },
+    "_prefix" : {
+        name : "Juan del Sur",
+        first : "Juan",
+        last : "del Sur"
+    },
+    "_prefix_with_period" : {
+        name : "Jill St. John",
+        first : "Jill",
+        last : "St. John"
+    },
+    "_prefix_before_two_part_last_name" : {
+        name : "pennie von bergen wessels",
+        first : "pennie",
+        last : "von bergen wessels"
+    },
+    "_prefix_before_two_part_last_name_with_suffix" : {
+        name : "pennie von bergen wessels III",
+        first : "pennie",
+        last : "von bergen wessels",
+        suffix : "III"
+    },
+    "_two_part_last_name_with_suffix_comma" : {
+        name : "pennie von bergen wessels, III",
+        first : "pennie",
+        last : "von bergen wessels",
+        suffix : "III"
+    },
+    "_two_part_last_name_with_suffix" : {
+        name : "von bergen wessels, pennie III",
+        first : "pennie",
+        last : "von bergen wessels",
+        suffix : "III"
+    },
+    "_suffix" : {
+        name : "Joe Franklin Jr",
+        first : "Joe",
+        last : "Franklin",
+        suffix : "Jr"
+    },
+    "_suffix_with_periods" : {
+        name : "Joe Dentist D.D.S.",
+        first : "Joe",
+        last : "Dentist",
+        suffix : "D.D.S."
+    },
+    "_two_suffixes_suffix_comma_format" : {
+        name : "Franklin Washington, Jr. MD",
+        first : "Franklin",
+        last : "Washington",
+        suffix : "Jr. MD"
+    },
+    "_suffix_containing_periods" : {
+        name : "Kenneth Clarke Q.C.",
+        first : "Kenneth",
+        last : "Clarke",
+        suffix : "Q.C."
+    },
+    "_suffix_containing_periods_lastname_comma_format" : {
+        name : "Clarke, Kenneth, Q.C. M.P.",
+        first : "Kenneth",
+        last : "Clarke",
+        suffix : "Q.C. M.P."
+    },
+    "_suffix_containing_periods_suffix_comma_format" : {
+        name : "Kenneth Clarke Q.C., M.P.",
+        first : "Kenneth",
+        last : "Clarke",
+        suffix : "Q.C., M.P."
+    },
+    "_suffix_with_single_comma_format" : {
+        name : "John Doe jr., MD",
+        first : "John",
+        last : "Doe",
+        suffix : "jr., MD"
+    },
+    "_suffix_with_double_comma_format" : {
+        name : "Doe, John jr., MD",
+        first : "John",
+        last : "Doe",
+        suffix : "jr., MD"
+    },
+    "_potential_suffix_that_is_also_last_name" : {
+        name : "Jack Ma",
+        first : "Jack",
+        last : "Ma"
+    },
+    "_potential_suffix_that_is_also_last_name_comma" : {
+        name : "Ma, Jack",
+        first : "Jack",
+        last : "Ma"
+    },
+    "_potential_suffix_that_is_also_first_name_comma" : {
+        name : "Johnson, Bart",
+        first : "Bart",
+        last : "Johnson"
+    },
+    "_potential_suffix_that_is_also_last_name_with_suffix" : {
+        name : "Jack Ma Jr",
+        first : "Jack",
+        last : "Ma",
+        suffix : "Jr"
+    },
+    "_potential_suffix_that_is_also_last_name_with_suffix_comma" : {
+        name : "Ma III, Jack Jr",
+        first : "Jack",
+        last : "Ma",
+        suffix : "III, Jr"
+    },
+    "_suffix_with_periods" : {
+        name : "John Doe Msc.Ed.",
+        first : "John",
+        last : "Doe",
+        suffix : "Msc.Ed."
+    },
+    "_suffix_with_periods_with_comma" : {
+        name : "John Doe, Msc.Ed.",
+        first : "John",
+        last : "Doe",
+        suffix : "Msc.Ed."
+    },
+    "_suffix_with_periods_with_lastname_comma" : {
+        name : "Doe, John Msc.Ed.",
+        first : "John",
+        last : "Doe",
+        suffix : "Msc.Ed."
+    },
+    "_last_name_is_also_title" : {
+        name : "Amy E Maid",
+        first : "Amy",
+        middle : "E",
+        last : "Maid"
+    },
+    "_last_name_is_also_title_no_comma" : {
+        name : "Dr. Martin Luther King Jr.",
+        title : "Dr.",
+        first : "Martin",
+        middle : "Luther",
+        last : "King",
+        suffix : "Jr."
+    },
+    "_last_name_is_also_title_with_comma" : {
+        name : "Duke Martin Luther King, Jr.",
+        title : "Duke",
+        first : "Martin",
+        middle : "Luther",
+        last : "King",
+        suffix : "Jr."
+    },
+    "_last_name_is_also_title3" : {
+        name : "John King",
+        first : "John",
+        last : "King"
+    },
+    "_title_with_conjunction" : {
+        name : "Secretary of State Hillary Clinton",
+        title : "Secretary of State",
+        first : "Hillary",
+        last : "Clinton"
+    },
+    "_compound_title_with_conjunction" : {
+        name : "Cardinal Secretary of State Hillary Clinton",
+        title : "Cardinal Secretary of State",
+        first : "Hillary",
+        last : "Clinton"
+    },
+    "_title_is_title" : {
+        name : "Coach",
+        title : "Coach"
+    },
+    "_conflict_with_chained_title_first_name_initial" : {
+        name : "U. S. Grant",
+        first : "U.",
+        middle : "S.",
+        last : "Grant"
+    },
+    "_chained_title_first_name_initial" : {
+        name : "US Magistrate Judge T Michael Putnam",
+        title : "US Magistrate Judge",
+        first : "T",
+        middle : "Michael",
+        last : "Putnam"
+    },
+    "_chained_hyphenated_title" : {
+        name : "US Magistrate-Judge Elizabeth E Campbell",
+        title : "US Magistrate-Judge",
+        first : "Elizabeth",
+        middle : "E",
+        last : "Campbell"
+    },
+    "_chained_hyphenated_title_with_comma_suffix" : {
+        name : "Mag-Judge Harwell G Davis, III",
+        title : "Mag-Judge",
+        first : "Harwell",
+        middle : "G",
+        last : "Davis",
+        suffix : "III"
+    },
+    "_title_starts_with_conjunction" : {
+        name : "The Rt Hon John Jones",
+        title : "The Rt Hon",
+        first : "John",
+        last : "Jones"
+    },
+    "_conjunction_before_title" : {
+        name : 'The Lord of the Universe',
+        title : "The Lord of the Universe"
+    },
+    "_double_conjunction_on_title" : {
+        name : 'Lord of the Universe',
+        title : "Lord of the Universe"
+    },
+    "_triple_conjunction_on_title" : {
+        name : 'Lord and of the Universe',
+        title : "Lord and of the Universe"
+    },
+    "_multiple_conjunctions_on_multiple_titles" : {
+        name : 'Lord of the Universe and Associate Supreme Queen of the World Lisa Simpson',
+        title : "Lord of the Universe and Associate Supreme Queen of the World",
+        first : "Lisa",
+        last : "Simpson"
+    },
+    "_title_with_last_initial_is_suffix" : {
+        name : "King John V.",
+        title : "King",
+        first : "John",
+        last : "V."
+    },
+    "_two_title_parts_separated_by_periods" : {
+        name : "Lt.Gen. John A. Kenneth Doe IV",
+        title : "Lt.Gen.",
+        first : "John",
+        last : "Doe",
+        middle : "A. Kenneth",
+        suffix : "IV"
+    },
+    "_two_part_title" : {
+        name : "Lt. Gen. John A. Kenneth Doe IV",
+        title : "Lt. Gen.",
+        first : "John",
+        last : "Doe",
+        middle : "A. Kenneth",
+        suffix : "IV"
+    },
+    "_two_part_title_with_lastname_comma" : {
+        name : "Doe, Lt. Gen. John A. Kenneth IV",
+        title : "Lt. Gen.",
+        first : "John",
+        last : "Doe",
+        middle : "A. Kenneth",
+        suffix : "IV"
+    },
+    "_two_part_title_with_suffix_comma" : {
+        name : "Lt. Gen. John A. Kenneth Doe, Jr.",
+        title : "Lt. Gen.",
+        first : "John",
+        last : "Doe",
+        middle : "A. Kenneth",
+        suffix : "Jr."
+    },
+    "_possible_conflict_with_middle_initial_that_could_be_suffix" : {
+        name : "Doe, Rev. John V, Jr.",
+        title : "Rev.",
+        first : "John",
+        last : "Doe",
+        middle : "V",
+        suffix : "Jr."
+    },
+    "_possible_conflict_with_suffix_that_could_be_initial" : {
+        name : "Doe, Rev. John A., V, Jr.",
+        title : "Rev.",
+        first : "John",
+        last : "Doe",
+        middle : "A.",
+        suffix : "V, Jr."
+    },
+    "_ben_as_first_name" : {
+        name : "Ben Johnson",
+        first : "Ben",
+        last : "Johnson"
+    },
+    "_ben_as_first_name_with_middle_name" : {
+        name : "Ben Alex Johnson",
+        first : "Ben",
+        middle : "Alex",
+        last : "Johnson"
+    },
+    "_ben_as_middle_name" : {
+        name : "Alex Ben Johnson",
+        first : "Alex",
+        middle : "Ben",
+        last : "Johnson"
+    },
+    "_last_name_also_prefix" : {
+        name : "Jane Doctor",
+        first : "Jane",
+        last : "Doctor"
+    },
+    "_title_with_periods" : {
+        name : "Lt.Gov. John Doe",
+        title : "Lt.Gov.",
+        first : "John",
+        last : "Doe"
+    },
+    "_title_with_periods_lastname_comma" : {
+        name : "Doe, Lt.Gov. John",
+        title : "Lt.Gov.",
+        first : "John",
+        last : "Doe"
+    }
+}

--- a/testnames.json
+++ b/testnames.json
@@ -4,11 +4,6 @@
         "first" : "Jüan",
         "last" : "de la Véña"
     },
-    "_escaped_utf8_bytes" : {
-        "name" : b'B\xc3\xb6ck, Gerald',
-        "first" : "Gerald",
-        "last" : "Böck"
-    },
     "_conjunction_names" : {
         "name" : "johnny y",
         "first" : "johnny",

--- a/testnames.json
+++ b/testnames.json
@@ -862,7 +862,7 @@
         "last" : "Almighty"
     },
     "_last_name_with_conjunction" : {
-        "name" : 'Jose Aznar y Lopez',
+        "name" : "Jose Aznar y Lopez",
         "first" : "Jose",
         "last" : "Aznar y Lopez"
     },
@@ -895,62 +895,62 @@
         "last" : "Dough"
     },
     "_uppercase_middle_initial_conflict_with_conjunction" : {
-        "name" : 'John E Smith',
+        "name" : "John E Smith",
         "first" : "John",
         "middle" : "E",
         "last" : "Smith"
     },
     "_lowercase_middle_initial_with_period_conflict_with_conjunction" : {
-        "name" : 'john e. smith',
+        "name" : "john e. smith",
         "first" : "john",
         "middle" : "e.",
         "last" : "smith"
     },
     "_lowercase_first_initial_conflict_with_conjunction" : {
-        "name" : 'e j smith',
+        "name" : "e j smith",
         "first" : "e",
         "middle" : "j",
         "last" : "smith"
     },
     "_lowercase_middle_initial_conflict_with_conjunction" : {
-        "name" : 'John e Smith',
+        "name" : "John e Smith",
         "first" : "John",
         "middle" : "e",
         "last" : "Smith"
     },
     "_lowercase_middle_initial_and_suffix_conflict_with_conjunction" : {
-        "name" : 'John e Smith, III',
+        "name" : "John e Smith, III",
         "first" : "John",
         "middle" : "e",
         "last" : "Smith",
         "suffix" : "III"
     },
     "_lowercase_middle_initial_and_nocomma_suffix_conflict_with_conjunction" : {
-        "name" : 'John e Smith III',
+        "name" : "John e Smith III",
         "first" : "John",
         "middle" : "e",
         "last" : "Smith",
         "suffix" : "III"
     },
     "_lowercase_middle_initial_comma_lastname_and_suffix_conflict_with_conjunction" : {
-        "name" : 'Smith, John e, III, Jr',
+        "name" : "Smith, John e, III, Jr",
         "first" : "John",
         "middle" : "e",
         "last" : "Smith",
         "suffix" : "III, Jr"
     },
     "_couples_names" : {
-        "name" : 'John and Jane Smith',
+        "name" : "John and Jane Smith",
         "first" : "John and Jane",
         "last" : "Smith"
     },
     "_couples_names_with_conjunction_lastname" : {
-        "name" : 'John and Jane Aznar y Lopez',
+        "name" : "John and Jane Aznar y Lopez",
         "first" : "John and Jane",
         "last" : "Aznar y Lopez"
     },
     "_couple_titles" : {
-        "name" : 'Mr. and Mrs. John and Jane Smith',
+        "name" : "Mr. and Mrs. John and Jane Smith",
         "title" : "Mr. and Mrs.",
         "first" : "John and Jane",
         "last" : "Smith"
@@ -1286,19 +1286,19 @@
         "last" : "Jones"
     },
     "_conjunction_before_title" : {
-        "name" : 'The Lord of the Universe',
+        "name" : "The Lord of the Universe",
         "title" : "The Lord of the Universe"
     },
     "_double_conjunction_on_title" : {
-        "name" : 'Lord of the Universe',
+        "name" : "Lord of the Universe",
         "title" : "Lord of the Universe"
     },
     "_triple_conjunction_on_title" : {
-        "name" : 'Lord and of the Universe',
+        "name" : "Lord and of the Universe",
         "title" : "Lord and of the Universe"
     },
     "_multiple_conjunctions_on_multiple_titles" : {
-        "name" : 'Lord of the Universe and Associate Supreme Queen of the World Lisa Simpson',
+        "name" : "Lord of the Universe and Associate Supreme Queen of the World Lisa Simpson",
         "title" : "Lord of the Universe and Associate Supreme Queen of the World",
         "first" : "Lisa",
         "last" : "Simpson"

--- a/tests.py
+++ b/tests.py
@@ -56,20 +56,14 @@ class HumanNameTestBase(unittest.TestCase):
 
 class HumanNamePythonTests(HumanNameTestBase):
 
-    def test_utf8(self):
-        hn = HumanName("de la Véña, Jüan")
-        self.m(hn.first, "Jüan", hn)
-        self.m(hn.last, "de la Véña", hn)
+
 
     def test_string_output(self):
         hn = HumanName("de la Véña, Jüan")
         print(hn)
         print(repr(hn))
 
-    def test_escaped_utf8_bytes(self):
-        hn = HumanName(b'B\xc3\xb6ck, Gerald')
-        self.m(hn.first, "Gerald", hn)
-        self.m(hn.last, "Böck", hn)
+
 
     def test_len(self):
         hn = HumanName("Doe-Ray, Dr. John P., CLU, CFP, LUTC")
@@ -174,31 +168,17 @@ class HumanNamePythonTests(HumanNameTestBase):
         with self.assertRaises(TypeError):
             hn["suffix"] = {"test":"test"}
 
-    def test_conjunction_names(self):
-        hn = HumanName("johnny y")
-        self.m(hn.first, "johnny", hn)
-        self.m(hn.last, "y", hn)
 
-    def test_prefix_names(self):
-        hn = HumanName("vai la")
-        self.m(hn.first, "vai", hn)
-        self.m(hn.last, "la", hn)
 
-    def test_blank_name(self):
-        hn = HumanName()
-        self.m(hn.first, "", hn)
-        self.m(hn.last, "", hn)
+
+
+
+
 
 class FirstNameHandlingTests(HumanNameTestBase):
-    def test_first_name(self):
-        hn = HumanName("Andrew")
-        self.m(hn.first, "Andrew", hn)
 
-    def test_assume_title_and_one_other_name_is_last_name(self):
-        hn = HumanName("Rev Andrews")
-        self.m(hn.title, "Rev", hn)
-        self.m(hn.last, "Andrews", hn)
-    
+
+
     # TODO: Seems "Andrews, M.D.", Andrews should be treated as a last name
     # but other suffixes like "George Jr." should be first names. Might be 
     # related to https://github.com/derek73/python-nameparser/issues/2
@@ -207,43 +187,24 @@ class FirstNameHandlingTests(HumanNameTestBase):
         hn = HumanName("Andrews, M.D.")
         self.m(hn.suffix, "M.D.", hn)
         self.m(hn.last, "Andrews", hn)
-    
-    def test_suffix_in_lastname_part_of_lastname_comma_format(self):
-        hn = HumanName("Smith Jr., John")
-        self.m(hn.last, "Smith", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.suffix, "Jr.", hn)
 
-    def test_sir_exception_to_first_name_rule(self):
-        hn = HumanName("Sir Gerald")
-        self.m(hn.title, "Sir", hn)
-        self.m(hn.first, "Gerald", hn)
-        
-    def test_king_exception_to_first_name_rule(self):
-        hn = HumanName("King Henry")
-        self.m(hn.title, "King", hn)
-        self.m(hn.first, "Henry", hn)
-        
-    def test_queen_exception_to_first_name_rule(self):
-        hn = HumanName("Queen Elizabeth")
-        self.m(hn.title, "Queen", hn)
-        self.m(hn.first, "Elizabeth", hn)
-        
-    def test_dame_exception_to_first_name_rule(self):
-        hn = HumanName("Dame Mary")
-        self.m(hn.title, "Dame", hn)
-        self.m(hn.first, "Mary", hn)
-        
+
+
+
+
+
+
+
+
+
+
     def test_first_name_is_not_prefix_if_only_two_parts(self):
         """When there are only two parts, don't join prefixes or conjunctions"""
         hn = HumanName("Van Nguyen")
         self.m(hn.first, "Van", hn)
         self.m(hn.last, "Nguyen", hn)
 
-    def test_first_name_is_not_prefix_if_only_two_parts_comma(self):
-        hn = HumanName("Nguyen, Van")
-        self.m(hn.first, "Van", hn)
-        self.m(hn.last, "Nguyen", hn)
+
 
     @unittest.expectedFailure
     def test_first_name_is_prefix_if_three_parts(self):
@@ -255,891 +216,273 @@ class FirstNameHandlingTests(HumanNameTestBase):
 
 class HumanNameBruteForceTests(HumanNameTestBase):
 
-    def test1(self):
-        hn = HumanName("John Doe")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-
-    def test2(self):
-        hn = HumanName("John Doe, Jr.")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test3(self):
-        hn = HumanName("John Doe III")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test4(self):
-        hn = HumanName("Doe, John")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-
-    def test5(self):
-        hn = HumanName("Doe, John, Jr.")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test6(self):
-        hn = HumanName("Doe, John III")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test7(self):
-        hn = HumanName("John A. Doe")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-
-    def test8(self):
-        hn = HumanName("John A. Doe, Jr")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.suffix, "Jr", hn)
-
-    def test9(self):
-        hn = HumanName("John A. Doe III")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test10(self):
-        hn = HumanName("Doe, John A.")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-
-    def test11(self):
-        hn = HumanName("Doe, John A., Jr.")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test12(self):
-        hn = HumanName("Doe, John A., III")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test13(self):
-        hn = HumanName("John A. Kenneth Doe")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-
-    def test14(self):
-        hn = HumanName("John A. Kenneth Doe, Jr.")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test15(self):
-        hn = HumanName("John A. Kenneth Doe III")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test16(self):
-        hn = HumanName("Doe, John. A. Kenneth")
-        self.m(hn.first, "John.", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-
-    def test17(self):
-        hn = HumanName("Doe, John. A. Kenneth, Jr.")
-        self.m(hn.first, "John.", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test18(self):
-        hn = HumanName("Doe, John. A. Kenneth III")
-        self.m(hn.first, "John.", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test19(self):
-        hn = HumanName("Dr. John Doe")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.title, "Dr.", hn)
-
-    def test20(self):
-        hn = HumanName("Dr. John Doe, Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test21(self):
-        hn = HumanName("Dr. John Doe III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test22(self):
-        hn = HumanName("Doe, Dr. John")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-
-    def test23(self):
-        hn = HumanName("Doe, Dr. John, Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test24(self):
-        hn = HumanName("Doe, Dr. John III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test25(self):
-        hn = HumanName("Dr. John A. Doe")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-
-    def test26(self):
-        hn = HumanName("Dr. John A. Doe, Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test27(self):
-        hn = HumanName("Dr. John A. Doe III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test28(self):
-        hn = HumanName("Doe, Dr. John A.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-
-    def test29(self):
-        hn = HumanName("Doe, Dr. John A. Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test30(self):
-        hn = HumanName("Doe, Dr. John A. III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test31(self):
-        hn = HumanName("Dr. John A. Kenneth Doe")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-
-    def test32(self):
-        hn = HumanName("Dr. John A. Kenneth Doe, Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test33(self):
-        hn = HumanName("Al Arnold Gore, Jr.")
-        self.m(hn.middle, "Arnold", hn)
-        self.m(hn.first, "Al", hn)
-        self.m(hn.last, "Gore", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test34(self):
-        hn = HumanName("Dr. John A. Kenneth Doe III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test35(self):
-        hn = HumanName("Doe, Dr. John A. Kenneth")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-
-    def test36(self):
-        hn = HumanName("Doe, Dr. John A. Kenneth Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test37(self):
-        hn = HumanName("Doe, Dr. John A. Kenneth III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test38(self):
-        hn = HumanName("Juan de la Vega")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test39(self):
-        hn = HumanName("Juan de la Vega, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test40(self):
-        hn = HumanName("Juan de la Vega III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test41(self):
-        hn = HumanName("de la Vega, Juan")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test42(self):
-        hn = HumanName("de la Vega, Juan, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test43(self):
-        hn = HumanName("de la Vega, Juan III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test44(self):
-        hn = HumanName("Juan Velasquez y Garcia")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test45(self):
-        hn = HumanName("Juan Velasquez y Garcia, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test46(self):
-        hn = HumanName("Juan Velasquez y Garcia III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test47(self):
-        hn = HumanName("Velasquez y Garcia, Juan")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test48(self):
-        hn = HumanName("Velasquez y Garcia, Juan, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test49(self):
-        hn = HumanName("Velasquez y Garcia, Juan III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test50(self):
-        hn = HumanName("Dr. Juan de la Vega")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test51(self):
-        hn = HumanName("Dr. Juan de la Vega, Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test52(self):
-        hn = HumanName("Dr. Juan de la Vega III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test53(self):
-        hn = HumanName("de la Vega, Dr. Juan")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test54(self):
-        hn = HumanName("de la Vega, Dr. Juan, Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test55(self):
-        hn = HumanName("de la Vega, Dr. Juan III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test56(self):
-        hn = HumanName("Dr. Juan Velasquez y Garcia")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test57(self):
-        hn = HumanName("Dr. Juan Velasquez y Garcia, Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test58(self):
-        hn = HumanName("Dr. Juan Velasquez y Garcia III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test59(self):
-        hn = HumanName("Velasquez y Garcia, Dr. Juan")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test60(self):
-        hn = HumanName("Velasquez y Garcia, Dr. Juan, Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test61(self):
-        hn = HumanName("Velasquez y Garcia, Dr. Juan III")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test62(self):
-        hn = HumanName("Juan Q. de la Vega")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test63(self):
-        hn = HumanName("Juan Q. de la Vega, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test64(self):
-        hn = HumanName("Juan Q. de la Vega III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test65(self):
-        hn = HumanName("de la Vega, Juan Q.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test66(self):
-        hn = HumanName("de la Vega, Juan Q., Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test67(self):
-        hn = HumanName("de la Vega, Juan Q. III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test68(self):
-        hn = HumanName("Juan Q. Velasquez y Garcia")
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test69(self):
-        hn = HumanName("Juan Q. Velasquez y Garcia, Jr.")
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test70(self):
-        hn = HumanName("Juan Q. Velasquez y Garcia III")
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test71(self):
-        hn = HumanName("Velasquez y Garcia, Juan Q.")
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test72(self):
-        hn = HumanName("Velasquez y Garcia, Juan Q., Jr.")
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test73(self):
-        hn = HumanName("Velasquez y Garcia, Juan Q. III")
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test74(self):
-        hn = HumanName("Dr. Juan Q. de la Vega")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test75(self):
-        hn = HumanName("Dr. Juan Q. de la Vega, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test76(self):
-        hn = HumanName("Dr. Juan Q. de la Vega III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test77(self):
-        hn = HumanName("de la Vega, Dr. Juan Q.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.title, "Dr.", hn)
-
-    def test78(self):
-        hn = HumanName("de la Vega, Dr. Juan Q., Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.suffix, "Jr.", hn)
-        self.m(hn.title, "Dr.", hn)
-
-    def test79(self):
-        hn = HumanName("de la Vega, Dr. Juan Q. III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.suffix, "III", hn)
-        self.m(hn.title, "Dr.", hn)
-
-    def test80(self):
-        hn = HumanName("Dr. Juan Q. Velasquez y Garcia")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test81(self):
-        hn = HumanName("Dr. Juan Q. Velasquez y Garcia, Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test82(self):
-        hn = HumanName("Dr. Juan Q. Velasquez y Garcia III")
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test83(self):
-        hn = HumanName("Velasquez y Garcia, Dr. Juan Q.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test84(self):
-        hn = HumanName("Velasquez y Garcia, Dr. Juan Q., Jr.")
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test85(self):
-        hn = HumanName("Velasquez y Garcia, Dr. Juan Q. III")
-        self.m(hn.middle, "Q.", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test86(self):
-        hn = HumanName("Juan Q. Xavier de la Vega")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test87(self):
-        hn = HumanName("Juan Q. Xavier de la Vega, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test88(self):
-        hn = HumanName("Juan Q. Xavier de la Vega III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test89(self):
-        hn = HumanName("de la Vega, Juan Q. Xavier")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test90(self):
-        hn = HumanName("de la Vega, Juan Q. Xavier, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test91(self):
-        hn = HumanName("de la Vega, Juan Q. Xavier III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test92(self):
-        hn = HumanName("Dr. Juan Q. Xavier de la Vega")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test93(self):
-        hn = HumanName("Dr. Juan Q. Xavier de la Vega, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test94(self):
-        hn = HumanName("Dr. Juan Q. Xavier de la Vega III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test95(self):
-        hn = HumanName("de la Vega, Dr. Juan Q. Xavier")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.last, "de la Vega", hn)
-
-    def test96(self):
-        hn = HumanName("de la Vega, Dr. Juan Q. Xavier, Jr.")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test97(self):
-        hn = HumanName("de la Vega, Dr. Juan Q. Xavier III")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.last, "de la Vega", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test98(self):
-        hn = HumanName("Juan Q. Xavier Velasquez y Garcia")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test99(self):
-        hn = HumanName("Juan Q. Xavier Velasquez y Garcia, Jr.")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test100(self):
-        hn = HumanName("Juan Q. Xavier Velasquez y Garcia III")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test101(self):
-        hn = HumanName("Velasquez y Garcia, Juan Q. Xavier")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test102(self):
-        hn = HumanName("Velasquez y Garcia, Juan Q. Xavier, Jr.")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test103(self):
-        hn = HumanName("Velasquez y Garcia, Juan Q. Xavier III")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test104(self):
-        hn = HumanName("Dr. Juan Q. Xavier Velasquez y Garcia")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test105(self):
-        hn = HumanName("Dr. Juan Q. Xavier Velasquez y Garcia, Jr.")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test106(self):
-        hn = HumanName("Dr. Juan Q. Xavier Velasquez y Garcia III")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test107(self):
-        hn = HumanName("Velasquez y Garcia, Dr. Juan Q. Xavier")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-
-    def test108(self):
-        hn = HumanName("Velasquez y Garcia, Dr. Juan Q. Xavier, Jr.")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "Jr.", hn)
-
-    def test109(self):
-        hn = HumanName("Velasquez y Garcia, Dr. Juan Q. Xavier III")
-        self.m(hn.middle, "Q. Xavier", hn)
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.last, "Velasquez y Garcia", hn)
-        self.m(hn.suffix, "III", hn)
-
-    def test110(self):
-        hn = HumanName("John Doe, CLU, CFP, LUTC")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "CLU, CFP, LUTC", hn)
-
-    def test111(self):
-        hn = HumanName("John P. Doe, CLU, CFP, LUTC")
-        self.m(hn.first, "John", hn)
-        self.m(hn.middle, "P.", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "CLU, CFP, LUTC", hn)
-
-    def test112(self):
-        hn = HumanName("Dr. John P. Doe-Ray, CLU, CFP, LUTC")
-        self.m(hn.first, "John", hn)
-        self.m(hn.middle, "P.", hn)
-        self.m(hn.last, "Doe-Ray", hn)
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.suffix, "CLU, CFP, LUTC", hn)
-
-    def test113(self):
-        hn = HumanName("Doe-Ray, Dr. John P., CLU, CFP, LUTC")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.middle, "P.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe-Ray", hn)
-        self.m(hn.suffix, "CLU, CFP, LUTC", hn)
-
-    def test115(self):
-        hn = HumanName("Hon. Barrington P. Doe-Ray, Jr.")
-        self.m(hn.title, "Hon.", hn)
-        self.m(hn.middle, "P.", hn)
-        self.m(hn.first, "Barrington", hn)
-        self.m(hn.last, "Doe-Ray", hn)
-
-    def test116(self):
-        hn = HumanName("Doe-Ray, Hon. Barrington P. Jr., CFP, LUTC")
-        self.m(hn.title, "Hon.", hn)
-        self.m(hn.middle, "P.", hn)
-        self.m(hn.first, "Barrington", hn)
-        self.m(hn.last, "Doe-Ray", hn)
-        self.m(hn.suffix, "Jr., CFP, LUTC", hn)
-
-    def test117(self):
-        hn = HumanName("Rt. Hon. Paul E. Mary")
-        self.m(hn.title, "Rt. Hon.", hn)
-        self.m(hn.first, "Paul", hn)
-        self.m(hn.middle, "E.", hn)
-        self.m(hn.last, "Mary", hn)
-
-    def test119(self):
-        hn = HumanName("Lord God Almighty")
-        self.m(hn.title, "Lord", hn)
-        self.m(hn.first, "God", hn)
-        self.m(hn.last, "Almighty", hn)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
 class HumanNameConjunctionTestCase(HumanNameTestBase):
-    # Last name with conjunction
-    def test_last_name_with_conjunction(self):
-        hn = HumanName('Jose Aznar y Lopez')
-        self.m(hn.first, "Jose", hn)
-        self.m(hn.last, "Aznar y Lopez", hn)
 
-    def test_multiple_conjunctions(self):
-        hn = HumanName("part1 of The part2 of the part3 and part4")
-        self.m(hn.first, "part1 of The part2 of the part3 and part4", hn)
+# Last name with conjunction
 
-    def test_multiple_conjunctions2(self):
-        hn = HumanName("part1 of and The part2 of the part3 And part4")
-        self.m(hn.first, "part1 of and The part2 of the part3 And part4", hn)
-    
-    def test_ends_with_conjunction(self):
-        hn = HumanName("Jon Dough and")
-        self.m(hn.first, "Jon", hn)
-        self.m(hn.last, "Dough and", hn)
 
-    def test_ends_with_two_conjunctions(self):
-        hn = HumanName("Jon Dough and of")
-        self.m(hn.first, "Jon", hn)
-        self.m(hn.last, "Dough and of", hn)
 
-    def test_starts_with_conjunction(self):
-        hn = HumanName("and Jon Dough")
-        self.m(hn.first, "and Jon", hn)
-        self.m(hn.last, "Dough", hn)
 
-    def test_starts_with_two_conjunctions(self):
-        hn = HumanName("the and Jon Dough")
-        self.m(hn.first, "the and Jon", hn)
-        self.m(hn.last, "Dough", hn)
 
-    # Potential conjunction/prefix treated as initial (because uppercase)
-    def test_uppercase_middle_initial_conflict_with_conjunction(self):
-        hn = HumanName('John E Smith')
-        self.m(hn.first, "John", hn)
-        self.m(hn.middle, "E", hn)
-        self.m(hn.last, "Smith", hn)
 
-    def test_lowercase_middle_initial_with_period_conflict_with_conjunction(self):
-        hn = HumanName('john e. smith')
-        self.m(hn.first, "john", hn)
-        self.m(hn.middle, "e.", hn)
-        self.m(hn.last, "smith", hn)
 
-    # The conjunction "e" can also be an initial
-    def test_lowercase_first_initial_conflict_with_conjunction(self):
-        hn = HumanName('e j smith')
-        self.m(hn.first, "e", hn)
-        self.m(hn.middle, "j", hn)
-        self.m(hn.last, "smith", hn)
 
-    def test_lowercase_middle_initial_conflict_with_conjunction(self):
-        hn = HumanName('John e Smith')
-        self.m(hn.first, "John", hn)
-        self.m(hn.middle, "e", hn)
-        self.m(hn.last, "Smith", hn)
 
-    def test_lowercase_middle_initial_and_suffix_conflict_with_conjunction(self):
-        hn = HumanName('John e Smith, III')
-        self.m(hn.first, "John", hn)
-        self.m(hn.middle, "e", hn)
-        self.m(hn.last, "Smith", hn)
-        self.m(hn.suffix, "III", hn)
 
-    def test_lowercase_middle_initial_and_nocomma_suffix_conflict_with_conjunction(self):
-        hn = HumanName('John e Smith III')
-        self.m(hn.first, "John", hn)
-        self.m(hn.middle, "e", hn)
-        self.m(hn.last, "Smith", hn)
-        self.m(hn.suffix, "III", hn)
 
-    def test_lowercase_middle_initial_comma_lastname_and_suffix_conflict_with_conjunction(self):
-        hn = HumanName('Smith, John e, III, Jr')
-        self.m(hn.first, "John", hn)
-        self.m(hn.middle, "e", hn)
-        self.m(hn.last, "Smith", hn)
-        self.m(hn.suffix, "III, Jr", hn)
+
+
+
+# Potential conjunction/prefix treated as initial (because uppercase)
+
+
+
+
+# The conjunction "e" can also be an initial
+
+
+
+
+
+
+
+
 
     @unittest.expectedFailure
     def test_two_initials_conflict_with_conjunction(self):
@@ -1149,94 +492,35 @@ class HumanNameConjunctionTestCase(HumanNameTestBase):
         self.m(hn.middle, "T.", hn)
         self.m(hn.last, "Smith", hn)
 
-    def test_couples_names(self):
-        hn = HumanName('John and Jane Smith')
-        self.m(hn.first, "John and Jane", hn)
-        self.m(hn.last, "Smith", hn)
 
-    def test_couples_names_with_conjunction_lastname(self):
-        hn = HumanName('John and Jane Aznar y Lopez')
-        self.m(hn.first, "John and Jane", hn)
-        self.m(hn.last, "Aznar y Lopez", hn)
 
-    def test_couple_titles(self):
-        hn = HumanName('Mr. and Mrs. John and Jane Smith')
-        self.m(hn.title, "Mr. and Mrs.", hn)
-        self.m(hn.first, "John and Jane", hn)
-        self.m(hn.last, "Smith", hn)
 
-    def test_title_with_three_part_name_last_initial_is_suffix_uppercase_no_period(self):
-        hn = HumanName("King John Alexander V")
-        self.m(hn.title, "King", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Alexander", hn)
-        self.m(hn.suffix, "V", hn)
 
-    def test_four_name_parts_with_suffix_that_could_be_initial_lowercase_no_period(self):
-        hn = HumanName("larry james edward johnson v")
-        self.m(hn.first, "larry", hn)
-        self.m(hn.middle, "james edward", hn)
-        self.m(hn.last, "johnson", hn)
-        self.m(hn.suffix, "v", hn)
 
-    def test_four_name_parts_with_suffix_that_could_be_initial_uppercase_no_period(self):
-        hn = HumanName("Larry James Johnson I")
-        self.m(hn.first, "Larry", hn)
-        self.m(hn.middle, "James", hn)
-        self.m(hn.last, "Johnson", hn)
-        self.m(hn.suffix, "I", hn)
 
-    def test_roman_numeral_initials(self):
-        hn = HumanName("Larry V I")
-        self.m(hn.first, "Larry", hn)
-        self.m(hn.middle, "V", hn)
-        self.m(hn.last, "I", hn)
-        self.m(hn.suffix, "", hn)
 
-    # tests for Rev. title (Reverend)
-    def test124(self):
-        hn = HumanName("Rev. John A. Kenneth Doe")
-        self.m(hn.title, "Rev.", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
 
-    def test125(self):
-        hn = HumanName("Rev John A. Kenneth Doe")
-        self.m(hn.title, "Rev", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
 
-    def test126(self):
-        hn = HumanName("Doe, Rev. John A. Jr.")
-        self.m(hn.title, "Rev.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.suffix, "Jr.", hn)
 
-    def test127(self):
-        hn = HumanName("Buca di Beppo")
-        self.m(hn.first, "Buca", hn)
-        self.m(hn.last, "di Beppo", hn)
 
-    def test_le_as_last_name(self):
-        hn = HumanName("Yin Le")
-        self.m(hn.first, "Yin", hn)
-        self.m(hn.last, "Le", hn)
 
-    def test_le_as_last_name_with_middle_initial(self):
-        hn = HumanName("Yin a Le")
-        self.m(hn.first, "Yin", hn)
-        self.m(hn.middle, "a", hn)
-        self.m(hn.last, "Le", hn)
-        
-    def test_conjunction_in_an_address_with_a_title(self):
-        hn = HumanName("His Excellency Lord Duncan")
-        self.m(hn.title, "His Excellency Lord", hn)
-        self.m(hn.last, "Duncan", hn)
-        
+
+
+
+# tests for Rev. title (Reverend)
+
+
+
+
+
+
+
+
+
+
+
+
+
     @unittest.expectedFailure
     def test_conjunction_in_an_address_with_a_first_name_title(self):
         hn = HumanName("Her Majesty Queen Elizabeth")
@@ -1336,29 +620,13 @@ class ConstantsCustomization(HumanNameTestBase):
         self.assertEqual('', str(hn), hn)
 
 class HumanNameNicknameTestCase(HumanNameTestBase):
-    # https://code.google.com/p/python-nameparser/issues/detail?id=33
-    def test_nickname_in_parenthesis(self):
-        hn = HumanName("Benjamin (Ben) Franklin")
-        self.m(hn.first, "Benjamin", hn)
-        self.m(hn.middle, "", hn)
-        self.m(hn.last, "Franklin", hn)
-        self.m(hn.nickname, "Ben", hn)
-    
-    def test_nickname_in_parenthesis_with_comma(self):
-        hn = HumanName("Franklin, Benjamin (Ben)")
-        self.m(hn.first, "Benjamin", hn)
-        self.m(hn.middle, "", hn)
-        self.m(hn.last, "Franklin", hn)
-        self.m(hn.nickname, "Ben", hn)
-    
-    def test_nickname_in_parenthesis_with_comma_and_suffix(self):
-        hn = HumanName("Franklin, Benjamin (Ben), Jr.")
-        self.m(hn.first, "Benjamin", hn)
-        self.m(hn.middle, "", hn)
-        self.m(hn.last, "Franklin", hn)
-        self.m(hn.suffix, "Jr.", hn)
-        self.m(hn.nickname, "Ben", hn)
-    
+
+# https://code.google.com/p/python-nameparser/issues/detail?id=33
+
+
+
+
+
     # it would be hard to support this without breaking some of the
     # other examples with single quotes in the names.
     @unittest.expectedFailure
@@ -1369,34 +637,14 @@ class HumanNameNicknameTestCase(HumanNameTestBase):
         self.m(hn.last, "Franklin", hn)
         self.m(hn.nickname, "Ben", hn)
 
-    def test_nickname_in_double_quotes(self):
-        hn = HumanName("Benjamin \"Ben\" Franklin")
-        self.m(hn.first, "Benjamin", hn)
-        self.m(hn.middle, "", hn)
-        self.m(hn.last, "Franklin", hn)
-        self.m(hn.nickname, "Ben", hn)
-    
-    def test_single_quotes_on_first_name_not_treated_as_nickname(self):
-        hn = HumanName("Brian O'connor")
-        self.m(hn.first, "Brian", hn)
-        self.m(hn.middle, "", hn)
-        self.m(hn.last, "O'connor", hn)
-        self.m(hn.nickname, "", hn)
-    
-    def test_single_quotes_on_both_name_not_treated_as_nickname(self):
-        hn = HumanName("La'tanya O'connor")
-        self.m(hn.first, "La'tanya", hn)
-        self.m(hn.middle, "", hn)
-        self.m(hn.last, "O'connor", hn)
-        self.m(hn.nickname, "", hn)
-    
-    def test_single_quotes_on_end_of_last_name_not_treated_as_nickname(self):
-        hn = HumanName("Mari' Aube'")
-        self.m(hn.first, "Mari'", hn)
-        self.m(hn.middle, "", hn)
-        self.m(hn.last, "Aube'", hn)
-        self.m(hn.nickname, "", hn)
-    
+
+
+
+
+
+
+
+
     #http://code.google.com/p/python-nameparser/issues/detail?id=17
     def test_parenthesis_are_removed(self):
         hn = HumanName("John Jones (Google Docs)")
@@ -1404,62 +652,29 @@ class HumanNameNicknameTestCase(HumanNameTestBase):
         self.m(hn.last, "Jones", hn)
         # not testing the nicknames because we don't actually care
         # about Google Docs.
-        
-    def test_parenthesis_are_removed2(self):
-        hn = HumanName("John Jones (Google Docs), Jr. (Unknown)")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Jones", hn)
-        self.m(hn.suffix, "Jr.", hn)
+
+
 
 class PrefixesTestCase(HumanNameTestBase):
 
-    def test_prefix(self):
-        hn = HumanName("Juan del Sur")
-        self.m(hn.first, "Juan", hn)
-        self.m(hn.last, "del Sur", hn)
-    
-    def test_prefix_with_period(self):
-        hn = HumanName("Jill St. John")
-        self.m(hn.first, "Jill", hn)
-        self.m(hn.last, "St. John", hn)
-    
-    def test_prefix_before_two_part_last_name(self):
-        hn = HumanName("pennie von bergen wessels")
-        self.m(hn.first, "pennie", hn)
-        self.m(hn.last, "von bergen wessels", hn)
 
-    def test_prefix_before_two_part_last_name_with_suffix(self):
-        hn = HumanName("pennie von bergen wessels III")
-        self.m(hn.first, "pennie", hn)
-        self.m(hn.last, "von bergen wessels", hn)
-        self.m(hn.suffix, "III", hn)
 
-    def test_two_part_last_name_with_suffix_comma(self):
-        hn = HumanName("pennie von bergen wessels, III")
-        self.m(hn.first, "pennie", hn)
-        self.m(hn.last, "von bergen wessels", hn)
-        self.m(hn.suffix, "III", hn)
 
-    def test_two_part_last_name_with_suffix(self):
-        hn = HumanName("von bergen wessels, pennie III")
-        self.m(hn.first, "pennie", hn)
-        self.m(hn.last, "von bergen wessels", hn)
-        self.m(hn.suffix, "III", hn)
+
+
+
+
+
+
+
+
 
 
 class SuffixesTestCase(HumanNameTestBase):
-    
-    def test_suffix(self):
-        hn = HumanName("Joe Franklin Jr")
-        self.m(hn.first, "Joe", hn)
-        self.m(hn.last, "Franklin", hn)
-        self.m(hn.suffix, "Jr", hn)
 
-    def test_suffix_with_periods(self):
-        hn = HumanName("Joe Dentist D.D.S.")
-        self.m(hn.first, "Joe", hn)
-        self.m(hn.last, "Dentist", hn)
-        self.m(hn.suffix, "D.D.S.", hn)
+
+
+
 
     def test_two_suffixes(self):
         hn = HumanName("Kenneth Clarke QC MP")
@@ -1476,41 +691,17 @@ class SuffixesTestCase(HumanNameTestBase):
         # NOTE: this adds a comma when the orginal format did not have one. 
         self.m(hn.suffix, "Jr., MD", hn)
 
-    def test_two_suffixes_suffix_comma_format(self):
-        hn = HumanName("Franklin Washington, Jr. MD")
-        self.m(hn.first, "Franklin", hn)
-        self.m(hn.last, "Washington", hn)
-        self.m(hn.suffix, "Jr. MD", hn)
 
-    def test_suffix_containing_periods(self):
-        hn = HumanName("Kenneth Clarke Q.C.")
-        self.m(hn.first, "Kenneth", hn)
-        self.m(hn.last, "Clarke", hn)
-        self.m(hn.suffix, "Q.C.", hn)
 
-    def test_suffix_containing_periods_lastname_comma_format(self):
-        hn = HumanName("Clarke, Kenneth, Q.C. M.P.")
-        self.m(hn.first, "Kenneth", hn)
-        self.m(hn.last, "Clarke", hn)
-        self.m(hn.suffix, "Q.C. M.P.", hn)
 
-    def test_suffix_containing_periods_suffix_comma_format(self):
-        hn = HumanName("Kenneth Clarke Q.C., M.P.")
-        self.m(hn.first, "Kenneth", hn)
-        self.m(hn.last, "Clarke", hn)
-        self.m(hn.suffix, "Q.C., M.P.", hn)
 
-    def test_suffix_with_single_comma_format(self):
-        hn = HumanName("John Doe jr., MD")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "jr., MD", hn)
 
-    def test_suffix_with_double_comma_format(self):
-        hn = HumanName("Doe, John jr., MD")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.suffix, "jr., MD", hn)
+
+
+
+
+
+
 
     @unittest.expectedFailure
     def test_phd_with_erroneous_space(self):
@@ -1519,40 +710,23 @@ class SuffixesTestCase(HumanNameTestBase):
         self.m(hn.last, "Smith", hn)
         self.m(hn.suffix, "Ph. D.", hn)
 
-    #http://en.wikipedia.org/wiki/Ma_(surname)
-    def test_potential_suffix_that_is_also_last_name(self):
-        hn = HumanName("Jack Ma")
-        self.m(hn.first, "Jack", hn)
-        self.m(hn.last, "Ma", hn)
-    
-    def test_potential_suffix_that_is_also_last_name_comma(self):
-        hn = HumanName("Ma, Jack")
-        self.m(hn.first, "Jack", hn)
-        self.m(hn.last, "Ma", hn)
-    
-    def test_potential_suffix_that_is_also_first_name_comma(self):
-        hn = HumanName("Johnson, Bart")
-        self.m(hn.first, "Bart", hn)
-        self.m(hn.last, "Johnson", hn)
-    
+
+#http://en.wikipedia.org/wiki/Ma_(surname)
+
+
+
+
+
     # TODO: handle conjunctions in last names followed by first names clashing with suffixes
     @unittest.expectedFailure
     def test_potential_suffix_that_is_also_first_name_comma_with_conjunction(self):
         hn = HumanName("De la Vina, Bart")
         self.m(hn.first, "Bart", hn)
         self.m(hn.last, "De la Vina", hn)
-    
-    def test_potential_suffix_that_is_also_last_name_with_suffix(self):
-        hn = HumanName("Jack Ma Jr")
-        self.m(hn.first, "Jack", hn)
-        self.m(hn.last, "Ma", hn)
-        self.m(hn.suffix, "Jr", hn)
 
-    def test_potential_suffix_that_is_also_last_name_with_suffix_comma(self):
-        hn = HumanName("Ma III, Jack Jr")
-        self.m(hn.first, "Jack", hn)
-        self.m(hn.last, "Ma", hn)
-        self.m(hn.suffix, "III, Jr", hn)
+
+
+
 
     # https://github.com/derek73/python-nameparser/issues/27
     @unittest.expectedFailure
@@ -1562,69 +736,28 @@ class SuffixesTestCase(HumanNameTestBase):
         self.m(hn.last, "King", hn)
         self.m(hn.suffix, "Jr", hn)
 
-    def test_suffix_with_periods(self):
-        hn = HumanName("John Doe Msc.Ed.")
-        self.m(hn.first,"John", hn)
-        self.m(hn.last,"Doe", hn)
-        self.m(hn.suffix,"Msc.Ed.", hn)
 
-    def test_suffix_with_periods_with_comma(self):
-        hn = HumanName("John Doe, Msc.Ed.")
-        self.m(hn.first,"John", hn)
-        self.m(hn.last,"Doe", hn)
-        self.m(hn.suffix,"Msc.Ed.", hn)
 
-    def test_suffix_with_periods_with_lastname_comma(self):
-        hn = HumanName("Doe, John Msc.Ed.")
-        self.m(hn.first,"John", hn)
-        self.m(hn.last,"Doe", hn)
-        self.m(hn.suffix,"Msc.Ed.", hn)
+
+
+
 
 
 class TitleTestCase(HumanNameTestBase):
 
-    def test_last_name_is_also_title(self):
-        hn = HumanName("Amy E Maid")
-        self.m(hn.first, "Amy", hn)
-        self.m(hn.middle, "E", hn)
-        self.m(hn.last, "Maid", hn)
 
-    def test_last_name_is_also_title_no_comma(self):
-        hn = HumanName("Dr. Martin Luther King Jr.")
-        self.m(hn.title, "Dr.", hn)
-        self.m(hn.first, "Martin", hn)
-        self.m(hn.middle, "Luther", hn)
-        self.m(hn.last, "King", hn)
-        self.m(hn.suffix, "Jr.", hn)
 
-    def test_last_name_is_also_title_with_comma(self):
-        hn = HumanName("Duke Martin Luther King, Jr.")
-        self.m(hn.title, "Duke", hn)
-        self.m(hn.first, "Martin", hn)
-        self.m(hn.middle, "Luther", hn)
-        self.m(hn.last, "King", hn)
-        self.m(hn.suffix, "Jr.", hn)
 
-    def test_last_name_is_also_title3(self):
-        hn = HumanName("John King")
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "King", hn)
 
-    def test_title_with_conjunction(self):
-        hn = HumanName("Secretary of State Hillary Clinton")
-        self.m(hn.title, "Secretary of State", hn)
-        self.m(hn.first, "Hillary", hn)
-        self.m(hn.last, "Clinton", hn)
 
-    def test_compound_title_with_conjunction(self):
-        hn = HumanName("Cardinal Secretary of State Hillary Clinton")
-        self.m(hn.title, "Cardinal Secretary of State", hn)
-        self.m(hn.first, "Hillary", hn)
-        self.m(hn.last, "Clinton", hn)
 
-    def test_title_is_title(self):
-        hn = HumanName("Coach")
-        self.m(hn.title, "Coach", hn)
+
+
+
+
+
+
+
 
     # TODO: fix handling of U.S.
     @unittest.expectedFailure
@@ -1634,123 +767,49 @@ class TitleTestCase(HumanNameTestBase):
         self.m(hn.first, "Marc", hn)
         self.m(hn.middle, "Thomas", hn)
         self.m(hn.last, "Treadwell", hn)
-    
-    def test_conflict_with_chained_title_first_name_initial(self):
-        hn = HumanName("U. S. Grant")
-        self.m(hn.first, "U.", hn)
-        self.m(hn.middle, "S.", hn)
-        self.m(hn.last, "Grant", hn)
-    
-    def test_chained_title_first_name_initial(self):
-        hn = HumanName("US Magistrate Judge T Michael Putnam")
-        self.m(hn.title, "US Magistrate Judge", hn)
-        self.m(hn.first, "T", hn)
-        self.m(hn.middle, "Michael", hn)
-        self.m(hn.last, "Putnam", hn)
-    
-    def test_chained_hyphenated_title(self):
-        hn = HumanName("US Magistrate-Judge Elizabeth E Campbell")
-        self.m(hn.title, "US Magistrate-Judge", hn)
-        self.m(hn.first, "Elizabeth", hn)
-        self.m(hn.middle, "E", hn)
-        self.m(hn.last, "Campbell", hn)
-    
-    def test_chained_hyphenated_title_with_comma_suffix(self):
-        hn = HumanName("Mag-Judge Harwell G Davis, III")
-        self.m(hn.title, "Mag-Judge", hn)
-        self.m(hn.first, "Harwell", hn)
-        self.m(hn.middle, "G", hn)
-        self.m(hn.last, "Davis", hn)
-        self.m(hn.suffix, "III", hn)
+
+
+
+
+
+
+
+
 
     @unittest.expectedFailure
     def test_title_multiple_titles_with_apostrophe_s(self):
         hn = HumanName("The Right Hon. the President of the Queen's Bench Division")
         self.m(hn.title, "The Right Hon. the President of the Queen's Bench Division", hn)
 
-    def test_title_starts_with_conjunction(self):
-        hn = HumanName("The Rt Hon John Jones")
-        self.m(hn.title, "The Rt Hon", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Jones", hn)
 
-    def test_conjunction_before_title(self):
-        hn = HumanName('The Lord of the Universe')
-        self.m(hn.title, "The Lord of the Universe", hn)
 
-    def test_double_conjunction_on_title(self):
-        hn = HumanName('Lord of the Universe')
-        self.m(hn.title, "Lord of the Universe", hn)
 
-    def test_triple_conjunction_on_title(self):
-        hn = HumanName('Lord and of the Universe')
-        self.m(hn.title, "Lord and of the Universe", hn)
 
-    def test_multiple_conjunctions_on_multiple_titles(self):
-        hn = HumanName('Lord of the Universe and Associate Supreme Queen of the World Lisa Simpson')
-        self.m(hn.title, "Lord of the Universe and Associate Supreme Queen of the World", hn)
-        self.m(hn.first, "Lisa", hn)
-        self.m(hn.last, "Simpson", hn)
 
-    def test_title_with_last_initial_is_suffix(self):
-        hn = HumanName("King John V.")
-        self.m(hn.title, "King", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "V.", hn)
-        
+
+
+
+
+
+
+
     def test_initials_also_suffix(self):
         hn = HumanName("Smith, J.R.")
         self.m(hn.first, "J.R.", hn)
         # self.m(hn.middle, "R.", hn)
         self.m(hn.last, "Smith", hn)
 
-    def test_two_title_parts_separated_by_periods(self):
-        hn = HumanName("Lt.Gen. John A. Kenneth Doe IV")
-        self.m(hn.title, "Lt.Gen.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.suffix, "IV", hn)
 
-    def test_two_part_title(self):
-        hn = HumanName("Lt. Gen. John A. Kenneth Doe IV")
-        self.m(hn.title, "Lt. Gen.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.suffix, "IV", hn)
 
-    def test_two_part_title_with_lastname_comma(self):
-        hn = HumanName("Doe, Lt. Gen. John A. Kenneth IV")
-        self.m(hn.title, "Lt. Gen.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.suffix, "IV", hn)
 
-    def test_two_part_title_with_suffix_comma(self):
-        hn = HumanName("Lt. Gen. John A. Kenneth Doe, Jr.")
-        self.m(hn.title, "Lt. Gen.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A. Kenneth", hn)
-        self.m(hn.suffix, "Jr.", hn)
 
-    def test_possible_conflict_with_middle_initial_that_could_be_suffix(self):
-        hn = HumanName("Doe, Rev. John V, Jr.")
-        self.m(hn.title, "Rev.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "V", hn)
-        self.m(hn.suffix, "Jr.", hn)
 
-    def test_possible_conflict_with_suffix_that_could_be_initial(self):
-        hn = HumanName("Doe, Rev. John A., V, Jr.")
-        self.m(hn.title, "Rev.", hn)
-        self.m(hn.first, "John", hn)
-        self.m(hn.last, "Doe", hn)
-        self.m(hn.middle, "A.", hn)
-        self.m(hn.suffix, "V, Jr.", hn)
+
+
+
+
+
+
 
     # 'ben' is removed from PREFIXES in v0.2.5
     # this test could re-enable this test if we decide to support 'ben' as a prefix
@@ -1760,40 +819,18 @@ class TitleTestCase(HumanNameTestBase):
         self.m(hn.first,"Ahmad", hn)
         self.m(hn.last,"ben Husain", hn)
 
-    def test_ben_as_first_name(self):
-        hn = HumanName("Ben Johnson")
-        self.m(hn.first, "Ben", hn)
-        self.m(hn.last, "Johnson", hn)
 
-    def test_ben_as_first_name_with_middle_name(self):
-        hn = HumanName("Ben Alex Johnson")
-        self.m(hn.first, "Ben", hn)
-        self.m(hn.middle, "Alex", hn)
-        self.m(hn.last, "Johnson", hn)
 
-    def test_ben_as_middle_name(self):
-        hn = HumanName("Alex Ben Johnson")
-        self.m(hn.first, "Alex", hn)
-        self.m(hn.middle, "Ben", hn)
-        self.m(hn.last, "Johnson", hn)
 
-    # http://code.google.com/p/python-nameparser/issues/detail?id=13
-    def test_last_name_also_prefix(self):
-        hn = HumanName("Jane Doctor")
-        self.m(hn.first, "Jane", hn)
-        self.m(hn.last, "Doctor", hn)
 
-    def test_title_with_periods(self):
-        hn = HumanName("Lt.Gov. John Doe")
-        self.m(hn.title,"Lt.Gov.", hn)
-        self.m(hn.first,"John", hn)
-        self.m(hn.last,"Doe", hn)
 
-    def test_title_with_periods_lastname_comma(self):
-        hn = HumanName("Doe, Lt.Gov. John")
-        self.m(hn.title,"Lt.Gov.", hn)
-        self.m(hn.first,"John", hn)
-        self.m(hn.last,"Doe", hn)
+
+
+# http://code.google.com/p/python-nameparser/issues/detail?id=13
+
+
+
+
 
 class HumanNameCapitalizationTestCase(HumanNameTestBase):
     def test_capitalization_exception_for_III(self):

--- a/tests.py
+++ b/tests.py
@@ -53,7 +53,7 @@ class HumanNameTestBase(unittest.TestCase):
         except UnicodeDecodeError:
             self.assertEquals(actual, expected)
 
-class HumanNamePythonTests(HumanNameTestBase):
+class HumanNameBruteForceTests(HumanNameTestBase):
 
     def test_json_names(self):
         all_name_tests = json.load(open('testnames.json', 'r'))

--- a/tests.py
+++ b/tests.py
@@ -61,6 +61,11 @@ class HumanNamePythonTests(HumanNameTestBase):
         print(hn)
         print(repr(hn))
 
+    def test_escaped_utf8_bytes(self):
+        hn = HumanName(b'B\xc3\xb6ck, Gerald')
+        self.m(hn.first, "Gerald", hn)
+        self.m(hn.last, "Böck", hn)
+
     def test_len(self):
         hn = HumanName("Doe-Ray, Dr. John P., CLU, CFP, LUTC")
         self.m(len(hn), 5, hn)

--- a/tests.py
+++ b/tests.py
@@ -56,14 +56,10 @@ class HumanNameTestBase(unittest.TestCase):
 
 class HumanNamePythonTests(HumanNameTestBase):
 
-
-
     def test_string_output(self):
         hn = HumanName("de la Véña, Jüan")
         print(hn)
         print(repr(hn))
-
-
 
     def test_len(self):
         hn = HumanName("Doe-Ray, Dr. John P., CLU, CFP, LUTC")
@@ -168,16 +164,7 @@ class HumanNamePythonTests(HumanNameTestBase):
         with self.assertRaises(TypeError):
             hn["suffix"] = {"test":"test"}
 
-
-
-
-
-
-
-
 class FirstNameHandlingTests(HumanNameTestBase):
-
-
 
     # TODO: Seems "Andrews, M.D.", Andrews should be treated as a last name
     # but other suffixes like "George Jr." should be first names. Might be 
@@ -188,23 +175,11 @@ class FirstNameHandlingTests(HumanNameTestBase):
         self.m(hn.suffix, "M.D.", hn)
         self.m(hn.last, "Andrews", hn)
 
-
-
-
-
-
-
-
-
-
-
     def test_first_name_is_not_prefix_if_only_two_parts(self):
         """When there are only two parts, don't join prefixes or conjunctions"""
         hn = HumanName("Van Nguyen")
         self.m(hn.first, "Van", hn)
         self.m(hn.last, "Nguyen", hn)
-
-
 
     @unittest.expectedFailure
     def test_first_name_is_prefix_if_three_parts(self):
@@ -214,275 +189,7 @@ class FirstNameHandlingTests(HumanNameTestBase):
         self.m(hn.last, "Nguyen", hn)
         
 
-class HumanNameBruteForceTests(HumanNameTestBase):
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 class HumanNameConjunctionTestCase(HumanNameTestBase):
-
-# Last name with conjunction
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-# Potential conjunction/prefix treated as initial (because uppercase)
-
-
-
-
-# The conjunction "e" can also be an initial
-
-
-
-
-
-
-
-
 
     @unittest.expectedFailure
     def test_two_initials_conflict_with_conjunction(self):
@@ -491,35 +198,6 @@ class HumanNameConjunctionTestCase(HumanNameTestBase):
         self.m(hn.first, "E.", hn)
         self.m(hn.middle, "T.", hn)
         self.m(hn.last, "Smith", hn)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-# tests for Rev. title (Reverend)
-
-
-
-
-
-
-
-
-
-
-
-
 
     @unittest.expectedFailure
     def test_conjunction_in_an_address_with_a_first_name_title(self):
@@ -653,28 +331,7 @@ class HumanNameNicknameTestCase(HumanNameTestBase):
         # not testing the nicknames because we don't actually care
         # about Google Docs.
 
-
-
-class PrefixesTestCase(HumanNameTestBase):
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 class SuffixesTestCase(HumanNameTestBase):
-
-
-
-
 
     def test_two_suffixes(self):
         hn = HumanName("Kenneth Clarke QC MP")
@@ -691,18 +348,6 @@ class SuffixesTestCase(HumanNameTestBase):
         # NOTE: this adds a comma when the orginal format did not have one. 
         self.m(hn.suffix, "Jr., MD", hn)
 
-
-
-
-
-
-
-
-
-
-
-
-
     @unittest.expectedFailure
     def test_phd_with_erroneous_space(self):
         hn = HumanName("John Smith, Ph. D.")
@@ -710,23 +355,12 @@ class SuffixesTestCase(HumanNameTestBase):
         self.m(hn.last, "Smith", hn)
         self.m(hn.suffix, "Ph. D.", hn)
 
-
-#http://en.wikipedia.org/wiki/Ma_(surname)
-
-
-
-
-
     # TODO: handle conjunctions in last names followed by first names clashing with suffixes
     @unittest.expectedFailure
     def test_potential_suffix_that_is_also_first_name_comma_with_conjunction(self):
         hn = HumanName("De la Vina, Bart")
         self.m(hn.first, "Bart", hn)
         self.m(hn.last, "De la Vina", hn)
-
-
-
-
 
     # https://github.com/derek73/python-nameparser/issues/27
     @unittest.expectedFailure
@@ -736,28 +370,7 @@ class SuffixesTestCase(HumanNameTestBase):
         self.m(hn.last, "King", hn)
         self.m(hn.suffix, "Jr", hn)
 
-
-
-
-
-
-
-
 class TitleTestCase(HumanNameTestBase):
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     # TODO: fix handling of U.S.
     @unittest.expectedFailure
@@ -768,48 +381,16 @@ class TitleTestCase(HumanNameTestBase):
         self.m(hn.middle, "Thomas", hn)
         self.m(hn.last, "Treadwell", hn)
 
-
-
-
-
-
-
-
-
     @unittest.expectedFailure
     def test_title_multiple_titles_with_apostrophe_s(self):
         hn = HumanName("The Right Hon. the President of the Queen's Bench Division")
         self.m(hn.title, "The Right Hon. the President of the Queen's Bench Division", hn)
-
-
-
-
-
-
-
-
-
-
-
-
 
     def test_initials_also_suffix(self):
         hn = HumanName("Smith, J.R.")
         self.m(hn.first, "J.R.", hn)
         # self.m(hn.middle, "R.", hn)
         self.m(hn.last, "Smith", hn)
-
-
-
-
-
-
-
-
-
-
-
-
 
     # 'ben' is removed from PREFIXES in v0.2.5
     # this test could re-enable this test if we decide to support 'ben' as a prefix
@@ -818,19 +399,6 @@ class TitleTestCase(HumanNameTestBase):
         hn = HumanName("Ahmad ben Husain")
         self.m(hn.first,"Ahmad", hn)
         self.m(hn.last,"ben Husain", hn)
-
-
-
-
-
-
-
-
-# http://code.google.com/p/python-nameparser/issues/detail?id=13
-
-
-
-
 
 class HumanNameCapitalizationTestCase(HumanNameTestBase):
     def test_capitalization_exception_for_III(self):
@@ -1168,10 +736,8 @@ TEST_NAMES = (
     "US Magistrate Judge T Michael Putnam",
     "Designated Judge David A. Ezra",
     "Sr US District Judge Richard G Kopf",
-    "U.S. District Judge Marc Thomas Treadwell",
+    "U.S. District Judge Marc Thomas Treadwell")
     
-)
-
 
 class HumanNameVariationTests(HumanNameTestBase):
     # test automated variations of names in TEST_NAMES.

--- a/tests.py
+++ b/tests.py
@@ -30,6 +30,7 @@ from nameparser.config import Constants
 
 log = logging.getLogger('HumanName')
 
+import json
 import unittest
 try:
     unittest.expectedFailure
@@ -52,7 +53,17 @@ class HumanNameTestBase(unittest.TestCase):
         except UnicodeDecodeError:
             self.assertEquals(actual, expected)
 
+class HumanNamePythonTests(HumanNameTestBase):
 
+    def test_json_names(self):
+        all_name_tests = json.load(open('testnames.json', 'r'))
+        for testname in all_name_tests.keys():
+            hn = HumanName(all_name_tests[testname]['name'])
+            for part in all_name_tests[testname].keys():
+                if part == 'name': continue
+                self.m(getattr(hn, part),
+                       all_name_tests[testname][part],
+                       hn)
 
 class HumanNamePythonTests(HumanNameTestBase):
 


### PR DESCRIPTION
This PR takes all "simple" unit tests, and puts them into a single JSON file to help clean things up.

The result is `tests.py` reduced to 814 lines, and an easier way to bulk-add new names (just append them to the JSON file).

_simple_ here means a test with a single `HumanName(...)` call, followed by several `self.m(...)`, with nothing else. No other tests are ported.

Let me know what you think.
Cheers,

Miles