### PR TITLE
Avoid use of sys.version for checking Python version

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -133,7 +133,7 @@ class HumanName(object):
         return " ".join(self)
     
     def __str__(self):
-        if sys.version >= '3':
+        if sys.version_info[0] >= 3:
             return self.__unicode__()
         return self.__unicode__().encode(self.ENCODING)
     
@@ -150,7 +150,7 @@ class HumanName(object):
                 'suffix': self.suffix or '',
                 'nickname': self.nickname or '',
             }
-        if sys.version >= '3':
+        if sys.version_info[0] >= 3:
             return _string
         return _string.encode(self.ENCODING)
     

--- a/nameparser/util.py
+++ b/nameparser/util.py
@@ -13,7 +13,7 @@ log.setLevel(logging.ERROR)
 
 
 import sys
-if sys.version < '3':
+if sys.version_info[0] < 3:
 
     text_type = unicode
     binary_type = str


### PR DESCRIPTION
This changes the Python 2 / 3 version check to use `sys.version_info` as the version number is not guaranteed to be at the beginning of `sys.version` across Python implementations. Please also see the note in the documentation: https://docs.python.org/2/library/sys.html#sys.version.