### PR TITLE
Add titles for portuguese language

### DIFF
--- a/nameparser/config/titles.py
+++ b/nameparser/config/titles.py
@@ -245,6 +245,7 @@ TITLES = FIRST_NAME_TITLES | set([
     'doyen',
     'dpty',
     'dr',
+    'dra',
     'dramatist',
     'druid',
     'drummer',

--- a/nameparser/config/titles.py
+++ b/nameparser/config/titles.py
@@ -567,6 +567,7 @@ TITLES = FIRST_NAME_TITLES | set([
     'special',
     'sr',
     'sra',
+    'srta',
     'ssg',
     'ssgt',
     'staff',

--- a/tests.py
+++ b/tests.py
@@ -2167,6 +2167,7 @@ TEST_NAMES = (
     "Sr US District Judge Richard G Kopf",
     "U.S. District Judge Marc Thomas Treadwell",
     "Dra. Andréia da Silva",
+    "Srta. Andréia da Silva",
     
 )
 

--- a/tests.py
+++ b/tests.py
@@ -2166,6 +2166,7 @@ TEST_NAMES = (
     "Designated Judge David A. Ezra",
     "Sr US District Judge Richard G Kopf",
     "U.S. District Judge Marc Thomas Treadwell",
+    "Dra. Andréia da Silva",
     
 )
 


### PR DESCRIPTION
This pull request is to add to the list of titles 2 well-specific situations to the Portuguese language:

1) The title of physician/Doctor for women who is: Dra
2) How to refer to an unmarried woman: Srta