### PR TITLE
Prevent false nicknames due to multiple quotes

### DIFF
--- a/nameparser/config/regexes.py
+++ b/nameparser/config/regexes.py
@@ -23,7 +23,7 @@ REGEXES = set([
     ("word", re.compile(r"(\w|\.)+", re.U)),
     ("mac", re.compile(r'^(ma?c)(\w{2,})', re.I | re.U)),
     ("initial", re.compile(r'^(\w\.|[A-Z])?$', re.U)),
-    ("quoted_word", re.compile(r'\'([^\s]*?)\'', re.U)),
+    ("quoted_word", re.compile(r'(?<!\w)\'([^\s]*?)\'(?!\w)', re.U)),
     ("double_quotes", re.compile(r'\"(.*?)\"', re.U)),
     ("parenthesis", re.compile(r'\((.*?)\)', re.U)),
     ("roman_numeral", re.compile(r'^(X|IX|IV|V?I{0,3})$', re.I | re.U)),

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -413,9 +413,9 @@ class HumanName(object):
         The content of parenthesis or quotes in the name will be added to the 
         nicknames list. This happens before any other processing of the name.
         
-        Single quotes cannot span white space characters to allow for single
-        quotes in names like O'Connor. Double quotes and parenthesis can span
-        white space.
+        Single quotes cannot span white space characters and must border
+        white space to allow for quotes in names like O'Connor and Kawai'ae'a.
+        Double quotes and parenthesis can span white space.
         
         Loops through 3 :py:data:`~nameparser.config.regexes.REGEXES`; 
         `quoted_word`, `double_quotes` and `parenthesis`.

--- a/tests.py
+++ b/tests.py
@@ -1431,6 +1431,34 @@ class NicknameTestCase(HumanNameTestBase):
         self.m(hn.last, "Aube'", hn)
         self.m(hn.nickname, "", hn)
     
+    def test_okina_inside_name_not_treated_as_nickname(self):
+        hn = HumanName("Harrieta Keōpūolani Nāhiʻenaʻena")
+        self.m(hn.first, "Harrieta", hn)
+        self.m(hn.middle, "Keōpūolani", hn)
+        self.m(hn.last, "Nāhiʻenaʻena", hn)
+        self.m(hn.nickname, "", hn)
+
+    def test_single_quotes_not_treated_as_nickname_Hawaiian_example(self):
+        hn = HumanName("Harietta Keopuolani Nahi'ena'ena")
+        self.m(hn.first, "Harietta", hn)
+        self.m(hn.middle, "Keopuolani", hn)
+        self.m(hn.last, "Nahi'ena'ena", hn)
+        self.m(hn.nickname, "", hn)
+
+    def test_single_quotes_not_treated_as_nickname_Kenyan_example(self):
+        hn = HumanName("Naomi Wambui Ng'ang'a")
+        self.m(hn.first, "Naomi", hn)
+        self.m(hn.middle, "Wambui", hn)
+        self.m(hn.last, "Ng'ang'a", hn)
+        self.m(hn.nickname, "", hn)
+
+    def test_single_quotes_not_treated_as_nickname_Samoan_example(self):
+        hn = HumanName("Va'apu'u Vitale")
+        self.m(hn.first, "Va'apu'u", hn)
+        self.m(hn.middle, "", hn)
+        self.m(hn.last, "Vitale", hn)
+        self.m(hn.nickname, "", hn)
+
     # http://code.google.com/p/python-nameparser/issues/detail?id=17
     def test_parenthesis_are_removed_from_name(self):
         hn = HumanName("John Jones (Unknown)")


### PR DESCRIPTION
Certain Anglicized names such as those from some Hawaiian, Samoan,
and Kenyan traditions, include multiple single quotation marks.
This adjusts the quoted_word regex to only capture single quote
marks that are not inside words. Without this fix, false nicknames
are extracted from inside names like Ng'ang'a and Kawai'ae'a.
Tests are included to cover; existing Benjamin 'Ben' Franklin test
assures that the typical nickname case is unchanged.