### PR TITLE
Remove deprecated test case aliases and add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,rst,ini}]
+indent_style = space
+indent_size = 4
+
+[*.{html,json,yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ build
 .coverage
 dist
 .idea
+Pipfile
+Pipfile.lock
 
 # docs
 docs/_*

--- a/nameparser/config/capitalization.py
+++ b/nameparser/config/capitalization.py
@@ -2,11 +2,11 @@
 from __future__ import unicode_literals
 
 CAPITALIZATION_EXCEPTIONS = (
-    ('ii' ,'II'),
-    ('iii','III'),
-    ('iv' ,'IV'),
-    ('md' ,'M.D.'),
-    ('phd','Ph.D.'),
+    ('ii', 'II'),
+    ('iii', 'III'),
+    ('iv', 'IV'),
+    ('md', 'M.D.'),
+    ('phd', 'Ph.D.'),
 )
 """
 Any pieces that are not capitalized by capitalizing the first letter.

--- a/nameparser/config/prefixes.py
+++ b/nameparser/config/prefixes.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 #: Name pieces that appear before a last name. Prefixes join to the piece
 #: that follows them to make one new piece. They can be chained together, e.g
 #: "von der" and "de la". Because they only appear in middle or last names,
-#: they also signifiy that all following name pieces should be in the same name
+#: they also signify that all following name pieces should be in the same name
 #: part, for example, "von" will be joined to all following pieces that are not
 #: prefixes or suffixes, allowing recognition of double last names when they
 #: appear after a prefixes. So in "pennie von bergen wessels MD", "von" will

--- a/tests.py
+++ b/tests.py
@@ -40,7 +40,7 @@ except AttributeError:
 
 class HumanNameTestBase(unittest.TestCase):
     def m(self, actual, expected, hn):
-        """assertEquals with a better message and awareness of hn.C.empty_attribute_default"""
+        """assertEqual with a better message and awareness of hn.C.empty_attribute_default"""
         expected = expected or hn.C.empty_attribute_default
         try:
             self.assertEqual(actual, expected, "'%s' != '%s' for '%s'\n%r" % (
@@ -50,7 +50,7 @@ class HumanNameTestBase(unittest.TestCase):
                 hn
             ))
         except UnicodeDecodeError:
-            self.assertEquals(actual, expected)
+            self.assertEqual(actual, expected)
 
 
 class HumanNamePythonTests(HumanNameTestBase):
@@ -62,8 +62,6 @@ class HumanNamePythonTests(HumanNameTestBase):
 
     def test_string_output(self):
         hn = HumanName("de la Véña, Jüan")
-        print(hn)
-        print(repr(hn))
 
     def test_escaped_utf8_bytes(self):
         hn = HumanName(b'B\xc3\xb6ck, Gerald')
@@ -1267,7 +1265,7 @@ class ConstantsCustomization(HumanNameTestBase):
     def test_add_title(self):
         hn = HumanName("Te Awanui-a-Rangi Black", constants=None)
         start_len = len(hn.C.titles)
-        self.assert_(start_len > 0)
+        self.assertTrue(start_len > 0)
         hn.C.titles.add('te')
         self.assertEqual(start_len + 1, len(hn.C.titles))
         hn.parse_full_name()
@@ -1278,7 +1276,7 @@ class ConstantsCustomization(HumanNameTestBase):
     def test_remove_title(self):
         hn = HumanName("Hon Solo", constants=None)
         start_len = len(hn.C.titles)
-        self.assert_(start_len > 0)
+        self.assertTrue(start_len > 0)
         hn.C.titles.remove('hon')
         self.assertEqual(start_len - 1, len(hn.C.titles))
         hn.parse_full_name()


### PR DESCRIPTION
This also fixes a few minor spelling and spacing errors and ignores Pipenv files.