### PR TITLE
 Added capitalization rules to Constants class

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,rst,ini}]
+indent_style = space
+indent_size = 4
+
+[*.{html,json,yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ build
 .coverage
 dist
 .idea
+Pipfile
+Pipfile.lock
 
 # docs
 docs/_*

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -57,6 +57,8 @@ Other editable attributes
 
 * :py:obj:`~nameparser.config.Constants.string_format` - controls output from `str()`
 * :py:obj:`~nameparser.config.Constants.empty_attribute_default` - value returned by empty attributes, defaults to empty string
+* :py:obj:`~nameparser.config.Constants.capitalize_name` - If set, applies :py:meth:`~nameparser.parser.HumanName.capitalize` to :py:class:`~nameparser.parser.HumanName` instance.
+* :py:obj:`~nameparser.config.Constants.force_mixed_case_capitalization` - If set, forces the capitalization of mixed case strings when :py:meth:`~nameparser.parser.HumanName.capitalize` is called.
 
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,9 +72,8 @@ Capitalization Support
 
 The HumanName class can try to guess the correct capitalization of name
 entered in all upper or lower case. By default, it will not adjust 
-the case of names entered in mixed case. To run capitalization on all names
-pass the parameter `force=True`.
-
+the case of names entered in mixed case. To run capitalization on a
+`HumanName` instance, pass the parameter `force=True`.
 
     Capitalize the name.
 
@@ -92,6 +91,31 @@ pass the parameter `force=True`.
     'Shirley Maclaine'
     >>> name.capitalize(force=True)
     >>> str(name) 
+    'Shirley MacLaine'
+
+To apply capitalization to all `HumanName` instances, set
+:py:attr:`~nameparser.config.Constants.capitalize_name` to `True`.
+
+.. doctest:: capitalize_name
+    :options: +NORMALIZE_WHITESPACE
+
+    >>> from nameparser.config import CONSTANTS
+    >>> CONSTANTS.capitalize_name = True
+    >>> name = HumanName("bob v. de la macdole-eisenhower phd")
+    >>> str(name)
+    'Bob V. de la MacDole-Eisenhower Ph.D.'
+
+To force the capitalization of mixed case strings on all `HumanName` instances,
+set :py:attr:`~nameparser.config.Constants.force_mixed_case_capitalization` to `True`. 
+
+.. doctest:: force_mixed_case_capitalization
+    :options: +NORMALIZE_WHITESPACE
+
+    >>> from nameparser.config import CONSTANTS
+    >>> CONSTANTS.force_mixed_case_capitalization = True
+    >>> name = HumanName('Shirley Maclaine')
+    >>> name.capitalize()
+    >>> str(name)
     'Shirley MacLaine'
 
 

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -179,8 +179,37 @@ class Constants(object):
         'John'
         
     """
-    
-    
+    capitalize_name = False
+    """
+    If set, applies :py:meth:`~nameparser.parser.HumanName.capitalize` to
+    :py:class:`~nameparser.parser.HumanName` instance.
+
+    .. doctest::
+
+        >>> from nameparser.config import CONSTANTS
+        >>> CONSTANTS.capitalize_name = True
+        >>> name = HumanName("bob v. de la macdole-eisenhower phd")
+        >>> str(name)
+        'Bob V. de la MacDole-Eisenhower Ph.D.'
+
+    """
+    force_mixed_case_capitalization = False
+    """
+    If set, forces the capitalization of mixed case strings when
+    :py:meth:`~nameparser.parser.HumanName.capitalize` is called.
+
+    .. doctest::
+
+        >>> from nameparser.config import CONSTANTS
+        >>> CONSTANTS.force_mixed_case_capitalization = True
+        >>> name = HumanName('Shirley Maclaine')
+        >>> name.capitalize()
+        >>> str(name)
+        'Shirley MacLaine'
+
+    """
+
+
     def __init__(self, 
                     prefixes=PREFIXES, 
                     suffix_acronyms=SUFFIX_ACRONYMS,

--- a/nameparser/config/capitalization.py
+++ b/nameparser/config/capitalization.py
@@ -2,11 +2,11 @@
 from __future__ import unicode_literals
 
 CAPITALIZATION_EXCEPTIONS = (
-    ('ii' ,'II'),
-    ('iii','III'),
-    ('iv' ,'IV'),
-    ('md' ,'M.D.'),
-    ('phd','Ph.D.'),
+    ('ii', 'II'),
+    ('iii', 'III'),
+    ('iv', 'IV'),
+    ('md', 'M.D.'),
+    ('phd', 'Ph.D.'),
 )
 """
 Any pieces that are not capitalized by capitalizing the first letter.

--- a/nameparser/config/prefixes.py
+++ b/nameparser/config/prefixes.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 #: Name pieces that appear before a last name. Prefixes join to the piece
 #: that follows them to make one new piece. They can be chained together, e.g
 #: "von der" and "de la". Because they only appear in middle or last names,
-#: they also signifiy that all following name pieces should be in the same name
+#: they also signify that all following name pieces should be in the same name
 #: part, for example, "von" will be joined to all following pieces that are not
 #: prefixes or suffixes, allowing recognition of double last names when they
 #: appear after a prefixes. So in "pennie von bergen wessels MD", "von" will

--- a/tests.py
+++ b/tests.py
@@ -40,7 +40,7 @@ except AttributeError:
 
 class HumanNameTestBase(unittest.TestCase):
     def m(self, actual, expected, hn):
-        """assertEquals with a better message and awareness of hn.C.empty_attribute_default"""
+        """assertEqual with a better message and awareness of hn.C.empty_attribute_default"""
         expected = expected or hn.C.empty_attribute_default
         try:
             self.assertEqual(actual, expected, "'%s' != '%s' for '%s'\n%r" % (
@@ -50,7 +50,7 @@ class HumanNameTestBase(unittest.TestCase):
                 hn
             ))
         except UnicodeDecodeError:
-            self.assertEquals(actual, expected)
+            self.assertEqual(actual, expected)
 
 
 class HumanNamePythonTests(HumanNameTestBase):
@@ -62,8 +62,6 @@ class HumanNamePythonTests(HumanNameTestBase):
 
     def test_string_output(self):
         hn = HumanName("de la Véña, Jüan")
-        print(hn)
-        print(repr(hn))
 
     def test_escaped_utf8_bytes(self):
         hn = HumanName(b'B\xc3\xb6ck, Gerald')
@@ -1267,7 +1265,7 @@ class ConstantsCustomization(HumanNameTestBase):
     def test_add_title(self):
         hn = HumanName("Te Awanui-a-Rangi Black", constants=None)
         start_len = len(hn.C.titles)
-        self.assert_(start_len > 0)
+        self.assertTrue(start_len > 0)
         hn.C.titles.add('te')
         self.assertEqual(start_len + 1, len(hn.C.titles))
         hn.parse_full_name()
@@ -1278,7 +1276,7 @@ class ConstantsCustomization(HumanNameTestBase):
     def test_remove_title(self):
         hn = HumanName("Hon Solo", constants=None)
         start_len = len(hn.C.titles)
-        self.assert_(start_len > 0)
+        self.assertTrue(start_len > 0)
         hn.C.titles.remove('hon')
         self.assertEqual(start_len - 1, len(hn.C.titles))
         hn.parse_full_name()

--- a/tests.py
+++ b/tests.py
@@ -2088,6 +2088,28 @@ class HumanNameOutputFormatTests(HumanNameTestBase):
         self.assertEqual(u(hn), "TEST2")
         CONSTANTS.string_format = _orig
 
+    def test_capitalize_name_constants_attribute(self):
+        from nameparser.config import CONSTANTS
+        CONSTANTS.capitalize_name = True
+        hn = HumanName("bob v. de la macdole-eisenhower phd")
+        self.assertEqual(str(hn), "Bob V. de la MacDole-Eisenhower Ph.D.")
+        CONSTANTS.capitalize_name = False
+
+    def test_force_mixed_case_capitalization_constants_attribute(self):
+        from nameparser.config import CONSTANTS
+        CONSTANTS.force_mixed_case_capitalization = True
+        hn = HumanName('Shirley Maclaine')
+        hn.capitalize()
+        self.assertEqual(str(hn), "Shirley MacLaine")
+        CONSTANTS.force_mixed_case_capitalization = False
+
+    def test_capitalize_name_and_force_mixed_case_capitalization_constants_attributes(self):
+        from nameparser.config import CONSTANTS
+        CONSTANTS.capitalize_name = True
+        CONSTANTS.force_mixed_case_capitalization = True
+        hn = HumanName('Shirley Maclaine')
+        self.assertEqual(str(hn), "Shirley MacLaine")
+
     def test_quote_nickname_formating(self):
         hn = HumanName("Rev John A. Kenneth Doe III (Kenny)")
         hn.string_format = "{title} {first} {middle} {last} {suffix} '{nickname}'"


### PR DESCRIPTION
These changes let you set capitalization rules that are applied during instantiation.

Here are a few quick notes:
- I added the `handle_capitalization` method to keep inline with how you've setup post processing within the parser. 
- The `capitalize` method, when used with `force=True`, takes precedence over the `force_mixed_case_capitalization` setting. This ensures you get what you expect.
