### PR TITLE
Dep warning with importing from collections

### DIFF
--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -29,7 +29,7 @@ You can also adjust the configuration of individual instances by passing
 unexpected results. See `Customizing the Parser <customize.html>`_.
 """
 from __future__ import unicode_literals
-import collections
+from collections.abc import Set
 import sys
 
 from nameparser.util import binary_type
@@ -45,7 +45,7 @@ from nameparser.config.regexes import REGEXES
 
 DEFAULT_ENCODING = 'UTF-8'
 
-class SetManager(collections.Set):
+class SetManager(Set):
     '''
     Easily add and remove config variables per module or instance. Subclass of
     ``collections.Set``.


### PR DESCRIPTION
```
venv/lib/python3.7/site-packages/nameparser/config/__init__.py:48: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    class SetManager(collections.Set):
```