### PR TITLE
Updating Set import to work with py38

### DIFF
--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -29,8 +29,8 @@ You can also adjust the configuration of individual instances by passing
 unexpected results. See `Customizing the Parser <customize.html>`_.
 """
 from __future__ import unicode_literals
-import collections
 import sys
+from collections.abc import Set
 
 from nameparser.util import binary_type
 from nameparser.util import lc
@@ -45,10 +45,10 @@ from nameparser.config.regexes import REGEXES
 
 DEFAULT_ENCODING = 'UTF-8'
 
-class SetManager(collections.Set):
+class SetManager(Set):
     '''
     Easily add and remove config variables per module or instance. Subclass of
-    ``collections.Set``.
+    ``collections.abc.Set``.
     
     Only special functionality beyond that provided by set() is
     to normalize constants for comparison (lower case, no periods)


### PR DESCRIPTION
Hi @derek73, we use your tool in a project, and have been looking into upgrading our stack to Python 3.8.

However, it seems like the good folk as Python have moved `Set` from `collections` to `collections.abc`. Changing that in this PR.