### PR TITLE
run the parsing of pieces for post-comma parts prior to checking if a…

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -528,6 +528,9 @@ class HumanName(object):
             # in the first part. (Suffixes will never appear after last names
             # only, and allows potential first names to be in suffixes, e.g.
             # "Johnson, Bart"
+
+            post_comma_pieces = self.parse_pieces(parts[1].split(' '), 1)
+
             if self.are_suffixes(parts[1].split(' ')) \
                     and len(parts[0].split(' ')) > 1:
                 
@@ -566,9 +569,8 @@ class HumanName(object):
                 # lastname comma: 
                 # last [suffix], title first middles[,] suffix [,suffix]
                 #      parts[0],      parts[1],              parts[2:...]
-                pieces = self.parse_pieces(parts[1].split(' '), 1)
                 
-                log.debug("pieces: %s", u(pieces))
+                log.debug("post-comma pieces: %s", u(post_comma_pieces))
                 
                 # lastname part may have suffixes in it
                 lastname_pieces = self.parse_pieces(parts[0].split(' '), 1)
@@ -580,14 +582,14 @@ class HumanName(object):
                     else:
                         self.last_list.append(piece)
                 
-                for i, piece in enumerate(pieces):
+                for i, piece in enumerate(post_comma_pieces):
                     try:
-                        nxt = pieces[i + 1]
+                        nxt = post_comma_pieces[i + 1]
                     except IndexError:
                         nxt = None
                     
                     if self.is_title(piece) \
-                            and (nxt or len(pieces) == 1) \
+                            and (nxt or len(post_comma_pieces) == 1) \
                             and not self.first:
                         self.title_list.append(piece)
                         continue


### PR DESCRIPTION
…ll post-comma elements are suffixes. this ensures that suffixes are properly captured in the constants prior to the all-suffix check. 

This is to fix an inconsistency issue where a name would get misparsed the first time it was parsed and correctly parsed any subsequent times.

Upstream:
>>> HumanName("David Roth, M.Ed")
<HumanName : [
	title: '' 
	first: 'M.Ed' 
	middle: '' 
	last: 'David Roth' 
	suffix: ''
	nickname: ''
]>
>>> HumanName("David Roth, M.Ed")
<HumanName : [
	title: '' 
	first: 'David' 
	middle: '' 
	last: 'Roth' 
	suffix: 'M.Ed'
	nickname: ''
]>


With Fix:
>>> HumanName("David Roth, M.Ed")
<HumanName : [
	title: '' 
	first: 'David' 
	middle: '' 
	last: 'Roth' 
	suffix: 'M.Ed'
	nickname: ''
]>
>>> HumanName("David Roth, M.Ed")
<HumanName : [
	title: '' 
	first: 'David' 
	middle: '' 
	last: 'Roth' 
	suffix: 'M.Ed'
	nickname: ''
]>

Tests were identical to upstream, 11 expected failures.

