### PR TITLE
Feature: Add first and middle name(s) initials 

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -181,24 +181,36 @@ Initials Support
 
 The HumanName class can try to get the correct representation of initials.
 Initials can be tricky as different format usages exist. 
-If you want to exclude on of the name parts from the initials, you can use one of the following boolean parameters:
-`exclude_last_name`, `exclude_middle_name` or `exclude_first_name`
+If you want to exclude on of the name parts from the initials, you can use the initials format by chainging
+:py:attr:`~nameparser.config.Constants.initials_format`
+Three attributes exist for the format, `first`, `middle` and `last`. 
 
-You can also force the behavior using the CONSTANTS:
-:py:attr:`~nameparser.config.Constants.force_exclude_last_name`
-:py:attr:`~nameparser.config.Constants.force_exclude_middle_name`
-:py:attr:`~nameparser.config.Constants.force_exclude_first_name`
+.. doctest:: initials format
+
+  >>> from nameparser.config import CONSTANTS
+  >>> CONSTANTS.initials_format = "{first} {middle}"
+  >>> HumanName("Doe, John A. Kenneth, Jr.").initials()
+  'J. A. K.'
+  >>> HumanName("Doe, John A. Kenneth, Jr.", initials_format="{last}, {first}).initials()
+  'D., J.'
+
 
 Furthermore, the delimiter for the string output can be set through:
 :py:attr:`~nameparser.config.Constants.initials_delimiter`
 
-.. doctest:: initials
+.. doctest:: initials delimiter
 
-    >>> name = HumanName("Doe, John A. Kenneth, Jr.")
-    >>> name.initials()
-    'J. A. K. D.'
-    >>> name.initials(exclude_last_name)
-    'J. A. K.'
-    >>> name.initials_list(exclude_middle_name):
-    ['J', 'D']
+  >>> HumanName("Doe, John A. Kenneth, Jr.", initials_delimiter=";").initials()
+  "J; A; K;"
+  >>> from nameparser.config import CONSTANTS
+  >>> CONSTANTS.initials_delimiter = "."
+  >>> HumanName("Doe, John A. Kenneth, Jr.", initials_format="{first}{middle}{last}).initials()
+  "J.A.K.D."
+
+If you want to receive a list representation of the initials, yo ucan use :py:meth:`~nameparser.HumanName.initials_list`.
+This function is unaffected by :py:attr:`~nameparser.config.Constants.initials_format`
+
+.. doctest:: list format
+  >>> HumanName("Doe, John A. Kenneth, Jr.", initials_delimiter=";").initials_list()
+  ["J", "A", "K", "D"]
     

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -176,3 +176,29 @@ Don't want to include nicknames in your output? No problem. Just omit that keywo
   'Dr. Juan de la Vega'
 
 
+Initials Support
+----------------
+
+The HumanName class can try to get the correct representation of initials.
+Initials can be tricky as different format usages exist. 
+If you want to exclude on of the name parts from the initials, you can use one of the following boolean parameters:
+`exclude_last_name`, `exclude_middle_name` or `exclude_first_name`
+
+You can also force the behavior using the CONSTANTS:
+:py:attr:`~nameparser.config.Constants.force_exclude_last_name`
+:py:attr:`~nameparser.config.Constants.force_exclude_middle_name`
+:py:attr:`~nameparser.config.Constants.force_exclude_first_name`
+
+Furthermore, the delimiter for the string output can be set through:
+:py:attr:`~nameparser.config.Constants.initials_delimiter`
+
+.. doctest:: initials
+
+    >>> name = HumanName("Doe, John A. Kenneth, Jr.")
+    >>> name.initials()
+    'J. A. K. D.'
+    >>> name.initials(exclude_last_name)
+    'J. A. K.'
+    >>> name.initials_list(exclude_middle_name):
+    ['J', 'D']
+    

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -172,6 +172,18 @@ class Constants(object):
     """
     The default string format use for all new `HumanName` instances.
     """
+
+    initials_format = "{first} {middle} {last}"
+    """
+    The default initials format used for all new `HumanName` instances.
+    """
+
+    initials_delimiter = "."
+    """
+    The default initials delimiter used for all new `HumanName` instances.
+    Will be used to add a delimiter between each initial.
+    """
+
     empty_attribute_default = ''
     """
     Default return value for empty attributes.
@@ -203,23 +215,6 @@ class Constants(object):
 
     """
 
-    initials_delimiter = '.'
-    """"
-    Determines how the initials from :py:meth:`~nameparser.parser.HumanName.initials` are seperated.
-
-    .. doctest::
-
-        >>> from nameparser.config import CONSTANTS
-        >>> HumanName('Shirley Maclaine').initials()
-        'S. M.'
-        >>> CONSTANTS.initials_delimiter = ''
-        >>> HumanName('Shirley Maclaine').initials()
-        'S M'
-        >>> CONSTANTS.initials_delimiter = '-'
-        >>> HumanName('Shirley Maclaine').initials()
-        'S- M-'
-    """
-
     force_mixed_case_capitalization = False
     """
     If set, forces the capitalization of mixed case strings when
@@ -234,57 +229,6 @@ class Constants(object):
         >>> str(name)
         'Shirley MacLaine'
 
-    """
-
-    force_exclude_last_name_initial = False
-    """
-    If True, forces the last name to be excluded in the initials when
-    :py:meth:`~nameparser.parser.HumanName.initials` or
-    :py:meth:`~nameparser.parser.HumanName.initials_list` is called.
-
-    .. doctest::
-
-        >>> from nameparser.config import CONSTANTS
-        >>> CONSTANTS.force_exclude_last_name_initial = True
-        >>> name = HumanName('Shirley Ashley Maclaine')
-        >>> name.initials()
-        'S. A.'
-        >>> name.initials_list()
-        ['S', 'A']
-    """
-
-    force_exclude_middle_name_initial = False
-    """
-    If True, forces the middle name to be included in the initials when
-    :py:meth:`~nameparser.parser.HumanName.initials` or
-    :py:meth:`~nameparser.parser.HumanName.initials_list` is called.
-
-    .. doctest::
-
-        >>> from nameparser.config import CONSTANTS
-        >>> CONSTANTS.force_exclude_middle_name_initial = True
-        >>> name = HumanName('Shirley Ashley Maclaine')
-        >>> name.initials()
-        'S. M.'
-        >>> name.initials_list()
-        ['S', 'M']
-    """
-
-    force_exclude_first_name_initial = False
-    """
-    If True, forces the first name to be included in the initials when
-    :py:meth:`~nameparser.parser.HumanName.initials` or
-    :py:meth:`~nameparser.parser.HumanName.initials_list` is called.
-
-    .. doctest::
-
-        >>> from nameparser.config import CONSTANTS
-        >>> CONSTANTS.force_exclude_first_name_initial = True
-        >>> name = HumanName('Shirley Ashley Maclaine')
-        >>> name.initials()
-        'A. M.'
-        >>> name.initials_list()
-        ['A', 'M']
     """
 
     def __init__(self,

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -49,35 +49,37 @@ from nameparser.config.regexes import REGEXES
 
 DEFAULT_ENCODING = 'UTF-8'
 
+
 class SetManager(Set):
     '''
     Easily add and remove config variables per module or instance. Subclass of
     ``collections.abc.Set``.
-    
+
     Only special functionality beyond that provided by set() is
     to normalize constants for comparison (lower case, no periods)
     when they are add()ed and remove()d and allow passing multiple 
     string arguments to the :py:func:`add()` and :py:func:`remove()` methods.
-    
+
     '''
+
     def __init__(self, elements):
         self.elements = set(elements)
-    
+
     def __call__(self):
         return self.elements
-    
+
     def __repr__(self):
-        return "SetManager({})".format(self.elements) # used for docs
-    
+        return "SetManager({})".format(self.elements)  # used for docs
+
     def __iter__(self):
         return iter(self.elements)
-    
+
     def __contains__(self, value):
         return value in self.elements
-    
+
     def __len__(self):
         return len(self.elements)
-    
+
     def next(self):
         return self.__next__()
 
@@ -89,7 +91,7 @@ class SetManager(Set):
             c = self.count
             self.count = c + 1
             return getattr(self, self.elements[c]) or next(self)
-    
+
     def add_with_encoding(self, s, encoding=None):
         """
         Add the lower case and no-period version of the string to the set. Pass an
@@ -111,7 +113,7 @@ class SetManager(Set):
         """
         [self.add_with_encoding(s) for s in strings]
         return self
-    
+
     def remove(self, *strings):
         """
         Remove the lower case and no-period version of the string arguments from the set.
@@ -126,10 +128,11 @@ class TupleManager(dict):
     A dictionary with dot.notation access. Subclass of ``dict``. Makes the tuple constants 
     more friendly.
     '''
+
     def __getattr__(self, attr):
         return self.get(attr)
-    __setattr__= dict.__setitem__
-    __delattr__= dict.__delitem__
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
 
     def __getstate__(self):
         return dict(self)
@@ -139,6 +142,7 @@ class TupleManager(dict):
 
     def __reduce__(self):
         return (TupleManager, (), self.__getstate__())
+
 
 class Constants(object):
     """
@@ -163,7 +167,7 @@ class Constants(object):
     :param regexes: 
         :py:attr:`regexes`  wrapped with :py:class:`TupleManager`.
     """
-    
+
     string_format = "{title} {first} {middle} {last} {suffix} ({nickname})"
     """
     The default string format use for all new `HumanName` instances.
@@ -183,6 +187,7 @@ class Constants(object):
         'John'
         
     """
+
     capitalize_name = False
     """
     If set, applies :py:meth:`~nameparser.parser.HumanName.capitalize` to
@@ -197,6 +202,24 @@ class Constants(object):
         'Bob V. de la MacDole-Eisenhower Ph.D.'
 
     """
+
+    initials_delimiter = '.'
+    """"
+    Determines how the initials from :py:meth:`~nameparser.parser.HumanName.initials` are seperated.
+
+    .. doctest::
+
+        >>> from nameparser.config import CONSTANTS
+        >>> HumanName('Shirley Maclaine').initials()
+        'S. M.'
+        >>> CONSTANTS.initials_delimiter = ''
+        >>> HumanName('Shirley Maclaine').initials()
+        'S M'
+        >>> CONSTANTS.initials_delimiter = '-'
+        >>> HumanName('Shirley Maclaine').initials()
+        'S- M-'
+    """
+
     force_mixed_case_capitalization = False
     """
     If set, forces the capitalization of mixed case strings when
@@ -213,27 +236,77 @@ class Constants(object):
 
     """
 
+    force_exclude_last_name_initial = False
+    """
+    If True, forces the last name to be excluded in the initials when
+    :py:meth:`~nameparser.parser.HumanName.initials` or
+    :py:meth:`~nameparser.parser.HumanName.initials_list` is called.
 
-    def __init__(self, 
-                    prefixes=PREFIXES, 
-                    suffix_acronyms=SUFFIX_ACRONYMS,
-                    suffix_not_acronyms=SUFFIX_NOT_ACRONYMS,
-                    titles=TITLES,
-                    first_name_titles=FIRST_NAME_TITLES,
-                    conjunctions=CONJUNCTIONS,
-                    capitalization_exceptions=CAPITALIZATION_EXCEPTIONS,
-                    regexes=REGEXES
-                ):
-        self.prefixes            = SetManager(prefixes)
-        self.suffix_acronyms     = SetManager(suffix_acronyms)
+    .. doctest::
+
+        >>> from nameparser.config import CONSTANTS
+        >>> CONSTANTS.force_exclude_last_name_initial = True
+        >>> name = HumanName('Shirley Ashley Maclaine')
+        >>> name.initials()
+        'S. A.'
+        >>> name.initials_list()
+        ['S', 'A']
+    """
+
+    force_exclude_middle_name_initial = False
+    """
+    If True, forces the middle name to be included in the initials when
+    :py:meth:`~nameparser.parser.HumanName.initials` or
+    :py:meth:`~nameparser.parser.HumanName.initials_list` is called.
+
+    .. doctest::
+
+        >>> from nameparser.config import CONSTANTS
+        >>> CONSTANTS.force_exclude_middle_name_initial = True
+        >>> name = HumanName('Shirley Ashley Maclaine')
+        >>> name.initials()
+        'S. M.'
+        >>> name.initials_list()
+        ['S', 'M']
+    """
+
+    force_exclude_first_name_initial = False
+    """
+    If True, forces the first name to be included in the initials when
+    :py:meth:`~nameparser.parser.HumanName.initials` or
+    :py:meth:`~nameparser.parser.HumanName.initials_list` is called.
+
+    .. doctest::
+
+        >>> from nameparser.config import CONSTANTS
+        >>> CONSTANTS.force_exclude_first_name_initial = True
+        >>> name = HumanName('Shirley Ashley Maclaine')
+        >>> name.initials()
+        'A. M.'
+        >>> name.initials_list()
+        ['A', 'M']
+    """
+
+    def __init__(self,
+                 prefixes=PREFIXES,
+                 suffix_acronyms=SUFFIX_ACRONYMS,
+                 suffix_not_acronyms=SUFFIX_NOT_ACRONYMS,
+                 titles=TITLES,
+                 first_name_titles=FIRST_NAME_TITLES,
+                 conjunctions=CONJUNCTIONS,
+                 capitalization_exceptions=CAPITALIZATION_EXCEPTIONS,
+                 regexes=REGEXES
+                 ):
+        self.prefixes = SetManager(prefixes)
+        self.suffix_acronyms = SetManager(suffix_acronyms)
         self.suffix_not_acronyms = SetManager(suffix_not_acronyms)
-        self.titles              = SetManager(titles)
-        self.first_name_titles   = SetManager(first_name_titles)
-        self.conjunctions        = SetManager(conjunctions)
+        self.titles = SetManager(titles)
+        self.first_name_titles = SetManager(first_name_titles)
+        self.conjunctions = SetManager(conjunctions)
         self.capitalization_exceptions = TupleManager(capitalization_exceptions)
-        self.regexes             = TupleManager(regexes)
+        self.regexes = TupleManager(regexes)
         self._pst = None
-    
+
     @property
     def suffixes_prefixes_titles(self):
         if not self._pst:
@@ -242,15 +315,16 @@ class Constants(object):
 
     def __repr__(self):
         return "<Constants() instance>"
-    
+
     def __setstate__(self, state):
         self.__init__(state)
-    
+
     def __getstate__(self):
         attrs = [x for x in dir(self) if not x.startswith('_')]
-        return dict([(a,getattr(self, a)) for a in attrs])
+        return dict([(a, getattr(self, a)) for a in attrs])
 
-#: A module-level instance of the :py:class:`Constants()` class. 
+
+#: A module-level instance of the :py:class:`Constants()` class.
 #: Provides a common instance for the module to share
 #: to easily adjust configuration for the entire module.
 #: See `Customizing the Parser with Your Own Configuration <customize.html>`_.

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -224,13 +224,21 @@ class HumanName(object):
                 "B. A."
         """
 
+        first_initials_list = [name[0] for name in self.first_list]
+        middle_initials_list = [name[0] for name in self.middle_list]
+        last_initials_list = [name[0] for name in self.last_list]
+
         initials_dict = {
-            "first":  (self.initials_delimiter + " ").join([name[0] for name in self.first_list if len(name)]) + self.initials_delimiter,
-            "middle": (self.initials_delimiter + " ").join([name[0] for name in self.middle_list if len(name)]) + self.initials_delimiter,
-            "last": (self.initials_delimiter + " ").join([name[0] for name in self.last_list if len(name)]) + self.initials_delimiter
+            "first":  (self.initials_delimiter + " ").join(first_initials_list) + self.initials_delimiter
+            if len(first_initials_list) else self.C.empty_attribute_default,
+            "middle": (self.initials_delimiter + " ").join(middle_initials_list) + self.initials_delimiter
+            if len(middle_initials_list) else self.C.empty_attribute_default,
+            "last": (self.initials_delimiter + " ").join(last_initials_list) + self.initials_delimiter
+            if len(last_initials_list) else self.C.empty_attribute_default
         }
 
-        return self.initials_format.format(**initials_dict)
+        _s = self.initials_format.format(**initials_dict)
+        return self.collapse_whitespace(_s)
 
     @property
     def has_own_config(self):

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -213,7 +213,7 @@ class HumanName(object):
 
         return initials_list
 
-    def initials(self, exclude_last_name=False, exclude_middle_name=False, exclude_first_name=False, ):
+    def initials(self, exclude_last_name=False, exclude_middle_name=False, exclude_first_name=False):
         """
             Return period-delimited initials of the first, middle and optionally last name.
 

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -15,6 +15,7 @@ from nameparser.config import DEFAULT_ENCODING
 
 ENCODING = 'utf-8'
 
+
 def group_contiguous_integers(data):
     """
     return list of tuples containing first and last index
@@ -26,6 +27,7 @@ def group_contiguous_integers(data):
         if len(group) > 1:
             ranges.append((group[0], group[-1]))
     return ranges
+
 
 class HumanName(object):
     """
@@ -67,12 +69,12 @@ class HumanName(object):
     """
 
     _count = 0
-    _members = ['title','first','middle','last','suffix','nickname']
+    _members = ['title', 'first', 'middle', 'last', 'suffix', 'nickname']
     unparsable = True
     _full_name = ''
 
     def __init__(self, full_name="", constants=CONSTANTS, encoding=DEFAULT_ENCODING,
-                string_format=None):
+                 string_format=None):
         self.C = constants
         if type(self.C) is not type(CONSTANTS):
             self.C = Constants()
@@ -130,7 +132,7 @@ class HumanName(object):
             # string_format = "{title} {first} {middle} {last} {suffix} ({nickname})"
             _s = self.string_format.format(**self.as_dict())
             # remove trailing punctuation from missing nicknames
-            _s = _s.replace(str(self.C.empty_attribute_default),'').replace(" ()","").replace(" ''","").replace(' ""',"")
+            _s = _s.replace(str(self.C.empty_attribute_default), '').replace(" ()", "").replace(" ''", "").replace(' ""', "")
             return self.collapse_whitespace(_s).strip(', ')
         return " ".join(self)
 
@@ -141,7 +143,7 @@ class HumanName(object):
 
     def __repr__(self):
         if self.unparsable:
-            _string = "<%(class)s : [ Unparsable ] >" % {'class': self.__class__.__name__,}
+            _string = "<%(class)s : [ Unparsable ] >" % {'class': self.__class__.__name__, }
         else:
             _string = "<%(class)s : [\n\ttitle: '%(title)s' \n\tfirst: '%(first)s' \n\tmiddle: '%(middle)s' \n\tlast: '%(last)s' \n\tsuffix: '%(suffix)s'\n\tnickname: '%(nickname)s'\n]>" % {
                 'class': self.__class__.__name__,
@@ -182,6 +184,54 @@ class HumanName(object):
                     d[m] = val
         return d
 
+    def initials_list(self, exclude_last_name=False, exclude_middle_name=False, exclude_first_name=False):
+        """
+            Return period-delimited initials of the first, middle and optionally last name.
+
+            :param bool exclude_last_name: Exclude the last name as part of the initials
+            :param bool exclude_middle_name: Exclude the middle name as part of the initials
+            :param bool exclude_first_name: Exclude the first name as part of the initials
+            :rtype: str
+
+            .. doctest::
+
+                >>> name = HumanName("Sir Bob Andrew Dole")
+                >>> name.initials()
+                ["B", "A", "D"]
+                >>> name.initials(False)
+                ["B", "A"]
+        """
+        initials_list = []
+        if not self.C.force_exclude_first_name_initial and not exclude_first_name:
+            initials_list = [name[0] for name in self.first_list if len(name)]
+
+        if not self.C.force_exclude_middle_name_initial and not exclude_middle_name:
+            initials_list += [name[0] for name in self.middle_list if len(name)]
+
+        if not self.C.force_exclude_last_name_initial and not exclude_last_name:
+            initials_list += [name[0] for name in self.last_list if len(name)]
+
+        return initials_list
+
+    def initials(self, exclude_last_name=False, exclude_middle_name=False, exclude_first_name=False, ):
+        """
+            Return period-delimited initials of the first, middle and optionally last name.
+
+            :param bool include_last_name: Include the last name as part of the initials
+            :rtype: str
+
+            .. doctest::
+
+                >>> name = HumanName("Sir Bob Andrew Dole")
+                >>> name.initials()
+                "B. A. D."
+                >>> name.initials(False)
+                "B. A."
+        """
+        initials_list = self.initials_list(exclude_last_name, exclude_middle_name, exclude_first_name)
+
+        return " ".join([initial + self.C.initials_delimiter for initial in initials_list]) or self.C.empty_attribute_default
+
     @property
     def has_own_config(self):
         """
@@ -190,7 +240,7 @@ class HumanName(object):
         """
         return self.C is not CONSTANTS
 
-    ### attributes
+    # attributes
 
     @property
     def title(self):
@@ -259,7 +309,7 @@ class HumanName(object):
         """
         return " ".join(self.surnames_list) or self.C.empty_attribute_default
 
-    ### setter methods
+    # setter methods
 
     def _set_list(self, attr, value):
         if isinstance(value, list):
@@ -270,8 +320,8 @@ class HumanName(object):
             val = []
         else:
             raise TypeError(
-                    "Can only assign strings, lists or None to name attributes."
-                    " Got {0}".format(type(value)))
+                "Can only assign strings, lists or None to name attributes."
+                " Got {0}".format(type(value)))
         setattr(self, attr+"_list", self.parse_pieces(val))
 
     @title.setter
@@ -298,7 +348,7 @@ class HumanName(object):
     def nickname(self, value):
         self._set_list('nickname', value)
 
-    ### Parse helpers
+    # Parse helpers
 
     def is_title(self, value):
         """Is in the :py:data:`~nameparser.config.titles.TITLES` set."""
@@ -331,8 +381,8 @@ class HumanName(object):
         `C.suffix_acronyms`.
         """
         # suffixes may have periods inside them like "M.D."
-        return ((lc(piece).replace('.','') in self.C.suffix_acronyms) \
-            or (lc(piece) in self.C.suffix_not_acronyms)) \
+        return ((lc(piece).replace('.', '') in self.C.suffix_acronyms)
+                or (lc(piece) in self.C.suffix_not_acronyms)) \
             and not self.is_an_initial(piece)
 
     def are_suffixes(self, pieces):
@@ -358,8 +408,7 @@ class HumanName(object):
         """
         return bool(self.C.regexes.initial.match(value))
 
-
-    ### full_name parser
+    # full_name parser
 
     @property
     def full_name(self):
@@ -376,7 +425,7 @@ class HumanName(object):
 
     def collapse_whitespace(self, string):
         # collapse multiple spaces into single space
-        string =  self.C.regexes.spaces.sub(" ", string.strip())
+        string = self.C.regexes.spaces.sub(" ", string.strip())
         if string.endswith(","):
             string = string[:-1]
         return string
@@ -404,7 +453,7 @@ class HumanName(object):
         self.handle_capitalization()
 
     def fix_phd(self):
-        _re =  self.C.regexes.phd
+        _re = self.C.regexes.phd
         match = _re.search(self._full_name)
         if match:
             self.suffix_list.append(match.group(1))
@@ -474,7 +523,6 @@ class HumanName(object):
         self.nickname_list = []
         self.unparsable = True
 
-
         self.pre_process()
 
         self._full_name = self.collapse_whitespace(self._full_name)
@@ -516,7 +564,7 @@ class HumanName(object):
                             # numeral but this piece is not an initial
                             self.is_roman_numeral(nxt) and i == p_len - 2
                             and not self.is_an_initial(piece)
-                        ):
+                ):
                     self.last_list.append(piece)
                     self.suffix_list += pieces[i+1:]
                     break
@@ -539,7 +587,6 @@ class HumanName(object):
                 # suffix comma:
                 # title first middle last [suffix], suffix [suffix] [, suffix]
                 #               parts[0],          parts[1:...]
-
 
                 self.suffix_list += parts[1:]
                 pieces = self.parse_pieces(parts[0].split(' '))
@@ -614,7 +661,6 @@ class HumanName(object):
             self.unparsable = False
         self.post_process()
 
-
     def parse_pieces(self, parts, additional_parts_count=0):
         """
         Split parts on spaces and remove commas, join on conjunctions and
@@ -648,7 +694,7 @@ class HumanName(object):
                 # split on periods, any of the split pieces titles or suffixes?
                 # ("Lt.Gov.")
                 period_chunks = part.split(".")
-                titles   = list(filter(self.is_title,  period_chunks))
+                titles = list(filter(self.is_title,  period_chunks))
                 suffixes = list(filter(self.is_suffix, period_chunks))
 
                 # add the part to the constant so it will be found
@@ -695,7 +741,7 @@ class HumanName(object):
         # other, then join those newly joined conjunctions and any single
         # conjunctions to the piece before and after it
         conj_index = [i for i, piece in enumerate(pieces)
-                                if self.is_conjunction(piece)]
+                      if self.is_conjunction(piece)]
 
         contiguous_conj_i = []
         for i, val in enumerate(conj_index):
@@ -710,14 +756,14 @@ class HumanName(object):
         delete_i = []
         for i in contiguous_conj_i:
             if type(i) == tuple:
-                new_piece = " ".join(pieces[ i[0] : i[1]+1] )
-                delete_i += list(range( i[0]+1, i[1]+1 ))
+                new_piece = " ".join(pieces[i[0]: i[1]+1])
+                delete_i += list(range(i[0]+1, i[1]+1))
                 pieces[i[0]] = new_piece
             else:
-                new_piece = " ".join(pieces[ i : i+2 ])
+                new_piece = " ".join(pieces[i: i+2])
                 delete_i += [i+1]
                 pieces[i] = new_piece
-            #add newly joined conjunctions to constants to be found later
+            # add newly joined conjunctions to constants to be found later
             self.C.conjunctions.add(new_piece)
 
         for i in reversed(delete_i):
@@ -747,9 +793,9 @@ class HumanName(object):
                 pieces[i] = new_piece
                 pieces.pop(i+1)
                 # subtract 1 from the index of all the remaining conjunctions
-                for j,val in enumerate(conj_index):
+                for j, val in enumerate(conj_index):
                     if val > i:
-                        conj_index[j]=val-1
+                        conj_index[j] = val-1
 
             else:
                 new_piece = " ".join(pieces[i-1:i+2])
@@ -766,10 +812,9 @@ class HumanName(object):
 
                 # subtract the number of removed pieces from the index
                 # of all the remaining conjunctions
-                for j,val in enumerate(conj_index):
+                for j, val in enumerate(conj_index):
                     if val > i:
                         conj_index[j] = val - rm_count
-
 
         # join prefixes to following lastnames: ['de la Vega'], ['van Buren']
         prefixes = list(filter(self.is_prefix, pieces))
@@ -813,12 +858,11 @@ class HumanName(object):
         log.debug("pieces: %s", pieces)
         return pieces
 
-
-    ### Capitalization Support
+    # Capitalization Support
 
     def cap_word(self, word, attribute):
-        if (self.is_prefix(word) and attribute in ('last','middle')) \
-                    or self.is_conjunction(word):
+        if (self.is_prefix(word) and attribute in ('last', 'middle')) \
+                or self.is_conjunction(word):
             return word.lower()
         exceptions = self.C.capitalization_exceptions
         if lc(word) in exceptions:
@@ -834,7 +878,8 @@ class HumanName(object):
     def cap_piece(self, piece, attribute):
         if not piece:
             return ""
-        replacement = lambda m: self.cap_word(m.group(0), attribute)
+
+        def replacement(m): return self.cap_word(m.group(0), attribute)
         return self.C.regexes.word.sub(replacement, piece)
 
     def capitalize(self, force=None):
@@ -872,10 +917,10 @@ class HumanName(object):
 
         if not force and not (name == name.upper() or name == name.lower()):
             return
-        self.title_list  = self.cap_piece(self.title , 'title').split(' ')
-        self.first_list  = self.cap_piece(self.first , 'first').split(' ')
+        self.title_list = self.cap_piece(self.title, 'title').split(' ')
+        self.first_list = self.cap_piece(self.first, 'first').split(' ')
         self.middle_list = self.cap_piece(self.middle, 'middle').split(' ')
-        self.last_list   = self.cap_piece(self.last  , 'last').split(' ')
+        self.last_list = self.cap_piece(self.last, 'last').split(' ')
         self.suffix_list = self.cap_piece(self.suffix, 'suffix').split(', ')
 
     def handle_capitalization(self):

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -188,6 +188,12 @@ class HumanName(object):
                     d[m] = val
         return d
 
+    def process_initial(self, name_part):
+        """
+            Name parts may include prefixes or conjuctions. This function filters these from the name.
+        """
+        return " ".join([split for split in name_part.split(" ") if len(split) and not (self.is_prefix(split) or self.is_conjunction(split))])[0]
+
     def initials_list(self):
         """
             Returns the initials as a list
@@ -195,18 +201,16 @@ class HumanName(object):
             .. doctest::
 
                 >>> name = HumanName("Sir Bob Andrew Dole")
-                >>> name.initials()
+                >>> name.initials_list()
                 ["B", "A", "D"]
                 >>> name = HumanName("J. Doe")
-                >>> name.initials()
+                >>> name.initials_list()
                 ["J", "D"]
         """
-        initials_list = []
-        initials_list = [name[0] for name in self.first_list if len(name)]
-        initials_list += [name[0] for name in self.middle_list if len(name)]
-        initials_list += [name[0] for name in self.last_list if len(name)]
-
-        return initials_list
+        first_initials_list = [self.__process_initial__(name) for name in self.first_list if name]
+        middle_initials_list = [self.__process_initial__(name) for name in self.middle_list if name]
+        last_initials_list = [self.__process_initial__(name) for name in self.last_list if name]
+        return first_initials_list + middle_initials_list + last_initials_list
 
     def initials(self):
         """
@@ -220,13 +224,14 @@ class HumanName(object):
                 >>> name = HumanName("Sir Bob Andrew Dole")
                 >>> name.initials()
                 "B. A. D."
-                >>> name.initials(False)
+                >>> name = HumanName("Sir Bob Andrew Dole", initials_format="{first} {middle}")
+                >>> name.initials()
                 "B. A."
         """
 
-        first_initials_list = [name[0] for name in self.first_list]
-        middle_initials_list = [name[0] for name in self.middle_list]
-        last_initials_list = [name[0] for name in self.last_list]
+        first_initials_list = [self.__process_initial__(name) for name in self.first_list if name]
+        middle_initials_list = [self.__process_initial__(name) for name in self.middle_list if name]
+        last_initials_list = [self.__process_initial__(name) for name in self.last_list if name]
 
         initials_dict = {
             "first":  (self.initials_delimiter + " ").join(first_initials_list) + self.initials_delimiter

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -192,7 +192,8 @@ class HumanName(object):
         """
             Name parts may include prefixes or conjuctions. This function filters these from the name.
         """
-        return " ".join([split for split in name_part.split(" ") if len(split) and not (self.is_prefix(split) or self.is_conjunction(split))])[0]
+        parsed = " ".join([split for split in name_part.split(" ") if len(split) and not (self.is_prefix(split) or self.is_conjunction(split))])
+        return parsed[0] if len(parsed) else ""
 
     def initials_list(self):
         """

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -188,7 +188,7 @@ class HumanName(object):
                     d[m] = val
         return d
 
-    def process_initial(self, name_part):
+    def __process_initial__(self, name_part):
         """
             Name parts may include prefixes or conjuctions. This function filters these from the name.
         """

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import unittest
 """
 Run this file to run the tests.
 
@@ -30,7 +31,6 @@ from nameparser.config import Constants
 
 log = logging.getLogger('HumanName')
 
-import unittest
 try:
     unittest.expectedFailure
 except AttributeError:
@@ -113,7 +113,6 @@ class HumanNamePythonTests(HumanNameTestBase):
         hn = HumanName("John Williams")
         hn.first_list = ["Larry"]
         self.m(hn.full_name, "Larry Williams", hn)
-
 
     def test_assignment_to_attribute(self):
         hn = HumanName("John A. Kenneth Doe, Jr.")
@@ -210,16 +209,16 @@ class FirstNameHandlingTests(HumanNameTestBase):
         hn = HumanName("Rev Andrews")
         self.m(hn.title, "Rev", hn)
         self.m(hn.last, "Andrews", hn)
-    
+
     # TODO: Seems "Andrews, M.D.", Andrews should be treated as a last name
-    # but other suffixes like "George Jr." should be first names. Might be 
+    # but other suffixes like "George Jr." should be first names. Might be
     # related to https://github.com/derek73/python-nameparser/issues/2
     @unittest.expectedFailure
     def test_assume_suffix_title_and_one_other_name_is_last_name(self):
         hn = HumanName("Andrews, M.D.")
         self.m(hn.suffix, "M.D.", hn)
         self.m(hn.last, "Andrews", hn)
-    
+
     def test_suffix_in_lastname_part_of_lastname_comma_format(self):
         hn = HumanName("Smith Jr., John")
         self.m(hn.last, "Smith", hn)
@@ -230,22 +229,22 @@ class FirstNameHandlingTests(HumanNameTestBase):
         hn = HumanName("Sir Gerald")
         self.m(hn.title, "Sir", hn)
         self.m(hn.first, "Gerald", hn)
-        
+
     def test_king_exception_to_first_name_rule(self):
         hn = HumanName("King Henry")
         self.m(hn.title, "King", hn)
         self.m(hn.first, "Henry", hn)
-        
+
     def test_queen_exception_to_first_name_rule(self):
         hn = HumanName("Queen Elizabeth")
         self.m(hn.title, "Queen", hn)
         self.m(hn.first, "Elizabeth", hn)
-        
+
     def test_dame_exception_to_first_name_rule(self):
         hn = HumanName("Dame Mary")
         self.m(hn.title, "Dame", hn)
         self.m(hn.first, "Mary", hn)
-        
+
     def test_first_name_is_not_prefix_if_only_two_parts(self):
         """When there are only two parts, don't join prefixes or conjunctions"""
         hn = HumanName("Van Nguyen")
@@ -263,7 +262,7 @@ class FirstNameHandlingTests(HumanNameTestBase):
         hn = HumanName("Mr. Van Nguyen")
         self.m(hn.first, "Van", hn)
         self.m(hn.last, "Nguyen", hn)
-        
+
 
 class HumanNameBruteForceTests(HumanNameTestBase):
 
@@ -1084,7 +1083,7 @@ class HumanNameConjunctionTestCase(HumanNameTestBase):
     def test_multiple_conjunctions2(self):
         hn = HumanName("part1 of and The part2 of the part3 And part4")
         self.m(hn.first, "part1 of and The part2 of the part3 And part4", hn)
-    
+
     def test_ends_with_conjunction(self):
         hn = HumanName("Jon Dough and")
         self.m(hn.first, "Jon", hn)
@@ -1242,12 +1241,12 @@ class HumanNameConjunctionTestCase(HumanNameTestBase):
         self.m(hn.first, "Yin", hn)
         self.m(hn.middle, "a", hn)
         self.m(hn.last, "Le", hn)
-        
+
     def test_conjunction_in_an_address_with_a_title(self):
         hn = HumanName("His Excellency Lord Duncan")
         self.m(hn.title, "His Excellency Lord", hn)
         self.m(hn.last, "Duncan", hn)
-        
+
     @unittest.expectedFailure
     def test_conjunction_in_an_address_with_a_first_name_title(self):
         hn = HumanName("Her Majesty Queen Elizabeth")
@@ -1272,7 +1271,7 @@ class ConstantsCustomization(HumanNameTestBase):
         self.m(hn.title, "Te", hn)
         self.m(hn.first, "Awanui-a-Rangi", hn)
         self.m(hn.last, "Black", hn)
-    
+
     def test_remove_title(self):
         hn = HumanName("Hon Solo", constants=None)
         start_len = len(hn.C.titles)
@@ -1282,7 +1281,7 @@ class ConstantsCustomization(HumanNameTestBase):
         hn.parse_full_name()
         self.m(hn.first, "Hon", hn)
         self.m(hn.last, "Solo", hn)
-    
+
     def test_add_multiple_arguments(self):
         hn = HumanName("Assoc Dean of Chemistry Robert Johns", constants=None)
         hn.C.titles.add('dean', 'Chemistry')
@@ -1310,7 +1309,7 @@ class ConstantsCustomization(HumanNameTestBase):
         self.assertEqual(hn2.has_own_config, False)
         # clean up so we don't mess up other tests
         hn.C.titles.add('hon')
-    
+
     def test_remove_multiple_arguments(self):
         hn = HumanName("Ms Hon Solo", constants=None)
         hn.C.titles.remove('hon', 'ms')
@@ -1370,7 +1369,7 @@ class NicknameTestCase(HumanNameTestBase):
         self.m(hn.middle, "", hn)
         self.m(hn.last, "Franklin", hn)
         self.m(hn.nickname, "Ben", hn)
-    
+
     def test_two_word_nickname_in_parenthesis(self):
         hn = HumanName("Benjamin (Big Ben) Franklin")
         self.m(hn.first, "Benjamin", hn)
@@ -1391,7 +1390,7 @@ class NicknameTestCase(HumanNameTestBase):
         self.m(hn.middle, "", hn)
         self.m(hn.last, "Franklin", hn)
         self.m(hn.nickname, "Ben", hn)
-    
+
     def test_nickname_in_parenthesis_with_comma_and_suffix(self):
         hn = HumanName("Franklin, Benjamin (Ben), Jr.")
         self.m(hn.first, "Benjamin", hn)
@@ -1399,7 +1398,7 @@ class NicknameTestCase(HumanNameTestBase):
         self.m(hn.last, "Franklin", hn)
         self.m(hn.suffix, "Jr.", hn)
         self.m(hn.nickname, "Ben", hn)
-    
+
     def test_nickname_in_single_quotes(self):
         hn = HumanName("Benjamin 'Ben' Franklin")
         self.m(hn.first, "Benjamin", hn)
@@ -1413,28 +1412,28 @@ class NicknameTestCase(HumanNameTestBase):
         self.m(hn.middle, "", hn)
         self.m(hn.last, "Franklin", hn)
         self.m(hn.nickname, "Ben", hn)
-    
+
     def test_single_quotes_on_first_name_not_treated_as_nickname(self):
         hn = HumanName("Brian Andrew O'connor")
         self.m(hn.first, "Brian", hn)
         self.m(hn.middle, "Andrew", hn)
         self.m(hn.last, "O'connor", hn)
         self.m(hn.nickname, "", hn)
-    
+
     def test_single_quotes_on_both_name_not_treated_as_nickname(self):
         hn = HumanName("La'tanya O'connor")
         self.m(hn.first, "La'tanya", hn)
         self.m(hn.middle, "", hn)
         self.m(hn.last, "O'connor", hn)
         self.m(hn.nickname, "", hn)
-    
+
     def test_single_quotes_on_end_of_last_name_not_treated_as_nickname(self):
         hn = HumanName("Mari' Aube'")
         self.m(hn.first, "Mari'", hn)
         self.m(hn.middle, "", hn)
         self.m(hn.last, "Aube'", hn)
         self.m(hn.nickname, "", hn)
-    
+
     def test_okina_inside_name_not_treated_as_nickname(self):
         hn = HumanName("Harrieta Keōpūolani Nāhiʻenaʻena")
         self.m(hn.first, "Harrieta", hn)
@@ -1492,7 +1491,6 @@ class NicknameTestCase(HumanNameTestBase):
         self.m(hn.nickname, "Rick", hn)
 
 
-
 # class MaidenNameTestCase(HumanNameTestBase):
 #
 #     def test_parenthesis_and_quotes_together(self):
@@ -1542,12 +1540,12 @@ class PrefixesTestCase(HumanNameTestBase):
         hn = HumanName("Juan del Sur")
         self.m(hn.first, "Juan", hn)
         self.m(hn.last, "del Sur", hn)
-    
+
     def test_prefix_with_period(self):
         hn = HumanName("Jill St. John")
         self.m(hn.first, "Jill", hn)
         self.m(hn.last, "St. John", hn)
-    
+
     def test_prefix_before_two_part_last_name(self):
         hn = HumanName("pennie von bergen wessels")
         self.m(hn.first, "pennie", hn)
@@ -1641,7 +1639,7 @@ class PrefixesTestCase(HumanNameTestBase):
 
 
 class SuffixesTestCase(HumanNameTestBase):
-    
+
     def test_suffix(self):
         hn = HumanName("Joe Franklin Jr")
         self.m(hn.first, "Joe", hn)
@@ -1716,13 +1714,13 @@ class SuffixesTestCase(HumanNameTestBase):
         self.m(hn.first, "Adolph", hn)
         self.m(hn.last, "D", hn)
 
-
     # http://en.wikipedia.org/wiki/Ma_(surname)
+
     def test_potential_suffix_that_is_also_last_name(self):
         hn = HumanName("Jack Ma")
         self.m(hn.first, "Jack", hn)
         self.m(hn.last, "Ma", hn)
-    
+
     def test_potential_suffix_that_is_also_last_name_comma(self):
         hn = HumanName("Ma, Jack")
         self.m(hn.first, "Jack", hn)
@@ -1820,27 +1818,27 @@ class TitleTestCase(HumanNameTestBase):
         self.m(hn.first, "Marc", hn)
         self.m(hn.middle, "Thomas", hn)
         self.m(hn.last, "Treadwell", hn)
-    
+
     def test_conflict_with_chained_title_first_name_initial(self):
         hn = HumanName("U. S. Grant")
         self.m(hn.first, "U.", hn)
         self.m(hn.middle, "S.", hn)
         self.m(hn.last, "Grant", hn)
-    
+
     def test_chained_title_first_name_initial_with_no_period(self):
         hn = HumanName("US Magistrate Judge T Michael Putnam")
         self.m(hn.title, "US Magistrate Judge", hn)
         self.m(hn.first, "T", hn)
         self.m(hn.middle, "Michael", hn)
         self.m(hn.last, "Putnam", hn)
-    
+
     def test_chained_hyphenated_title(self):
         hn = HumanName("US Magistrate-Judge Elizabeth E Campbell")
         self.m(hn.title, "US Magistrate-Judge", hn)
         self.m(hn.first, "Elizabeth", hn)
         self.m(hn.middle, "E", hn)
         self.m(hn.last, "Campbell", hn)
-    
+
     def test_chained_hyphenated_title_with_comma_suffix(self):
         hn = HumanName("Mag-Judge Harwell G Davis, III")
         self.m(hn.title, "Mag-Judge", hn)
@@ -1883,7 +1881,7 @@ class TitleTestCase(HumanNameTestBase):
         self.m(hn.title, "King", hn)
         self.m(hn.first, "John", hn)
         self.m(hn.last, "V.", hn)
-        
+
     def test_initials_also_suffix(self):
         hn = HumanName("Smith, J.R.")
         self.m(hn.first, "J.R.", hn)
@@ -2062,10 +2060,10 @@ class HumanNameCapitalizationTestCase(HumanNameTestBase):
 
 
 class HumanNameOutputFormatTests(HumanNameTestBase):
-    
+
     def test_formatting_init_argument(self):
         hn = HumanName("Rev John A. Kenneth Doe III (Kenny)",
-                        string_format="TEST1")
+                       string_format="TEST1")
         self.assertEqual(u(hn), "TEST1")
 
     def test_formatting_constants_attribute(self):
@@ -2160,7 +2158,7 @@ class HumanNameOutputFormatTests(HumanNameTestBase):
         self.assertEqual(u(hn), "Rev John (Kenny) A. Kenneth Doe III")
         hn.nickname = ''
         self.assertEqual(u(hn), "Rev John A. Kenneth Doe III")
-    
+
     def test_remove_emojis(self):
         hn = HumanName("Sam Smith 😊")
         self.m(hn.first, "Sam", hn)
@@ -2182,6 +2180,90 @@ class HumanNameOutputFormatTests(HumanNameTestBase):
         self.m(hn.last, "Smith😊", hn)
         self.assertEqual(u(hn), "∫≜⩕ Smith😊")
         # test cleanup
+
+
+class InitialsTestCase(HumanNameTestBase):
+    def test_initials(self):
+        hn = HumanName("Andrew Boris Petersen")
+        self.m(hn.initials(), "A. B. P.", hn)
+        self.m(hn.initials(exclude_last_name=True), "A. B.", hn)
+        self.m(hn.initials(exclude_middle_name=True), "A. P.", hn)
+        self.m(hn.initials(exclude_first_name=True), "B. P.", hn)
+
+    def test_initials_complex_name(self):
+        hn = HumanName("Doe, John A. Kenneth, Jr.")
+        self.m(hn.initials(), "J. A. K. D.", hn)
+        self.m(hn.initials(exclude_last_name=True), "J. A. K.", hn)
+        self.m(hn.initials(exclude_middle_name=True), "J. D.", hn)
+        self.m(hn.initials(exclude_first_name=True), "A. K. D.", hn)
+
+    def test_initials_list(self):
+        hn = HumanName("Andrew Boris Petersen")
+        self.m(hn.initials_list(), ["A", "B", "P"], hn)
+        self.m(hn.initials_list(exclude_last_name=True), ["A", "B"], hn)
+        self.m(hn.initials_list(exclude_middle_name=True), ["A", "P"], hn)
+        self.m(hn.initials_list(exclude_first_name=True), ["B", "P"], hn)
+
+    def test_initials_list_complex_name(self):
+        hn = HumanName("Doe, John A. Kenneth, Jr.")
+        self.m(hn.initials_list(), ["J", "A", "K", "D"], hn)
+        self.m(hn.initials_list(exclude_last_name=True), ["J", "A", "K"], hn)
+        self.m(hn.initials_list(exclude_middle_name=True), ["J", "D"], hn)
+        self.m(hn.initials_list(exclude_first_name=True), ["A", "K", "D"], hn)
+
+    def test_initials_configuration(self):
+        hn = HumanName("Doe, John A. Kenneth, Jr.")
+        from nameparser.config import CONSTANTS
+
+        CONSTANTS.force_exclude_last_name_initial = True
+        self.m(hn.initials(), "J. A. K.", hn)
+        self.m(hn.initials(exclude_last_name=True), "J. A. K.", hn)
+        self.m(hn.initials(exclude_middle_name=True), "J.", hn)
+        self.m(hn.initials(exclude_first_name=True), "A. K.", hn)
+        CONSTANTS.force_exclude_last_name_initial = False
+
+        CONSTANTS.force_exclude_middle_name_initial = True
+        self.m(hn.initials(), "J. D.", hn)
+        self.m(hn.initials(exclude_last_name=True), "J.", hn)
+        self.m(hn.initials(exclude_middle_name=True), "J. D.", hn)
+        self.m(hn.initials(exclude_first_name=True), "D.", hn)
+        CONSTANTS.force_exclude_middle_name_initial = False
+
+        CONSTANTS.force_exclude_first_name_initial = True
+        self.m(hn.initials(), "A. K. D.", hn)
+        self.m(hn.initials(exclude_last_name=True), "A. K.", hn)
+        self.m(hn.initials(exclude_middle_name=True), "D.", hn)
+        self.m(hn.initials(exclude_first_name=True), "A. K. D.", hn)
+        CONSTANTS.force_exclude_first_name_initial = False
+
+        CONSTANTS.initials_delimiter = ''
+        self.m(hn.initials(), "J A K D", hn)
+        CONSTANTS.initials_delimiter = '.'
+
+    def test_initials_configuration_list(self):
+        hn = HumanName("Doe, John A. Kenneth, Jr.")
+        from nameparser.config import CONSTANTS
+
+        CONSTANTS.force_exclude_last_name_initial = True
+        self.m(hn.initials_list(), ["J", "A", "K"], hn)
+        self.m(hn.initials_list(exclude_last_name=True), ["J", "A", "K"], hn)
+        self.m(hn.initials_list(exclude_middle_name=True), ["J"], hn)
+        self.m(hn.initials_list(exclude_first_name=True), ["A", "K"], hn)
+        CONSTANTS.force_exclude_last_name_initial = False
+
+        CONSTANTS.force_exclude_middle_name_initial = True
+        self.m(hn.initials_list(), ["J", "D"], hn)
+        self.m(hn.initials_list(exclude_last_name=True), ["J"], hn)
+        self.m(hn.initials_list(exclude_middle_name=True), ["J", "D"], hn)
+        self.m(hn.initials_list(exclude_first_name=True), ["D"], hn)
+        CONSTANTS.force_exclude_middle_name_initial = False
+
+        CONSTANTS.force_exclude_first_name_initial = True
+        self.m(hn.initials_list(), ["A", "K", "D"], hn)
+        self.m(hn.initials_list(exclude_last_name=True), ["A", "K"], hn)
+        self.m(hn.initials_list(exclude_middle_name=True), ["D"], hn)
+        self.m(hn.initials_list(exclude_first_name=True), ["A", "K", "D"], hn)
+        CONSTANTS.force_exclude_first_name_initial = False
 
 
 TEST_NAMES = (
@@ -2359,7 +2441,7 @@ TEST_NAMES = (
     "U.S. District Judge Marc Thomas Treadwell",
     "Dra. Andréia da Silva",
     "Srta. Andréia da Silva",
-    
+
 )
 
 

--- a/tests.py
+++ b/tests.py
@@ -2186,84 +2186,51 @@ class InitialsTestCase(HumanNameTestBase):
     def test_initials(self):
         hn = HumanName("Andrew Boris Petersen")
         self.m(hn.initials(), "A. B. P.", hn)
-        self.m(hn.initials(exclude_last_name=True), "A. B.", hn)
-        self.m(hn.initials(exclude_middle_name=True), "A. P.", hn)
-        self.m(hn.initials(exclude_first_name=True), "B. P.", hn)
 
     def test_initials_complex_name(self):
         hn = HumanName("Doe, John A. Kenneth, Jr.")
         self.m(hn.initials(), "J. A. K. D.", hn)
-        self.m(hn.initials(exclude_last_name=True), "J. A. K.", hn)
-        self.m(hn.initials(exclude_middle_name=True), "J. D.", hn)
-        self.m(hn.initials(exclude_first_name=True), "A. K. D.", hn)
+
+    def test_initials_format(self):
+        hn = HumanName("Doe, John A. Kenneth, Jr.", initials_format="{first} {middle}")
+        self.m(hn.initials(), "J. A. K.", hn)
+        hn = HumanName("Doe, John A. Kenneth, Jr.", initials_format="{first} {last}")
+        self.m(hn.initials(), "J. D.", hn)
+        hn = HumanName("Doe, John A. Kenneth, Jr.", initials_format="{middle} {last}")
+        self.m(hn.initials(), "A. K. D.", hn)
+        hn = HumanName("Doe, John A. Kenneth, Jr.", initials_format="{first}, {last}")
+        self.m(hn.initials(), "J., D.", hn)
+
+    def test_initials_format_constants(self):
+        from nameparser.config import CONSTANTS
+        orig_format = CONSTANTS.initials_format
+        CONSTANTS.initials_format = "{first} {last}"
+        hn = HumanName("Doe, John A. Kenneth, Jr.")
+        self.m(hn.initials(), "J. D.", hn)
+        CONSTANTS.initials_format = "{first}  {last}"
+        hn = HumanName("Doe, John A. Kenneth, Jr.")
+        self.m(hn.initials(), "J.  D.", hn)
+        CONSTANTS.initials_format = orig_format
+
+    def test_initials_delimiter(self):
+        hn = HumanName("Doe, John A. Kenneth, Jr.", initials_delimiter=";")
+        self.m(hn.initials(), "J; A; K; D;", hn)
+
+    def test_initials_delimiter_constants(self):
+        from nameparser.config import CONSTANTS
+        orig_delimiter = CONSTANTS.initials_delimiter
+        CONSTANTS.initials_delimiter = ";"
+        hn = HumanName("Doe, John A. Kenneth, Jr.")
+        self.m(hn.initials(), "J; A; K; D;", hn)
+        CONSTANTS.initials_delimiter = orig_delimiter
 
     def test_initials_list(self):
         hn = HumanName("Andrew Boris Petersen")
         self.m(hn.initials_list(), ["A", "B", "P"], hn)
-        self.m(hn.initials_list(exclude_last_name=True), ["A", "B"], hn)
-        self.m(hn.initials_list(exclude_middle_name=True), ["A", "P"], hn)
-        self.m(hn.initials_list(exclude_first_name=True), ["B", "P"], hn)
 
     def test_initials_list_complex_name(self):
         hn = HumanName("Doe, John A. Kenneth, Jr.")
         self.m(hn.initials_list(), ["J", "A", "K", "D"], hn)
-        self.m(hn.initials_list(exclude_last_name=True), ["J", "A", "K"], hn)
-        self.m(hn.initials_list(exclude_middle_name=True), ["J", "D"], hn)
-        self.m(hn.initials_list(exclude_first_name=True), ["A", "K", "D"], hn)
-
-    def test_initials_configuration(self):
-        hn = HumanName("Doe, John A. Kenneth, Jr.")
-        from nameparser.config import CONSTANTS
-
-        CONSTANTS.force_exclude_last_name_initial = True
-        self.m(hn.initials(), "J. A. K.", hn)
-        self.m(hn.initials(exclude_last_name=True), "J. A. K.", hn)
-        self.m(hn.initials(exclude_middle_name=True), "J.", hn)
-        self.m(hn.initials(exclude_first_name=True), "A. K.", hn)
-        CONSTANTS.force_exclude_last_name_initial = False
-
-        CONSTANTS.force_exclude_middle_name_initial = True
-        self.m(hn.initials(), "J. D.", hn)
-        self.m(hn.initials(exclude_last_name=True), "J.", hn)
-        self.m(hn.initials(exclude_middle_name=True), "J. D.", hn)
-        self.m(hn.initials(exclude_first_name=True), "D.", hn)
-        CONSTANTS.force_exclude_middle_name_initial = False
-
-        CONSTANTS.force_exclude_first_name_initial = True
-        self.m(hn.initials(), "A. K. D.", hn)
-        self.m(hn.initials(exclude_last_name=True), "A. K.", hn)
-        self.m(hn.initials(exclude_middle_name=True), "D.", hn)
-        self.m(hn.initials(exclude_first_name=True), "A. K. D.", hn)
-        CONSTANTS.force_exclude_first_name_initial = False
-
-        CONSTANTS.initials_delimiter = ''
-        self.m(hn.initials(), "J A K D", hn)
-        CONSTANTS.initials_delimiter = '.'
-
-    def test_initials_configuration_list(self):
-        hn = HumanName("Doe, John A. Kenneth, Jr.")
-        from nameparser.config import CONSTANTS
-
-        CONSTANTS.force_exclude_last_name_initial = True
-        self.m(hn.initials_list(), ["J", "A", "K"], hn)
-        self.m(hn.initials_list(exclude_last_name=True), ["J", "A", "K"], hn)
-        self.m(hn.initials_list(exclude_middle_name=True), ["J"], hn)
-        self.m(hn.initials_list(exclude_first_name=True), ["A", "K"], hn)
-        CONSTANTS.force_exclude_last_name_initial = False
-
-        CONSTANTS.force_exclude_middle_name_initial = True
-        self.m(hn.initials_list(), ["J", "D"], hn)
-        self.m(hn.initials_list(exclude_last_name=True), ["J"], hn)
-        self.m(hn.initials_list(exclude_middle_name=True), ["J", "D"], hn)
-        self.m(hn.initials_list(exclude_first_name=True), ["D"], hn)
-        CONSTANTS.force_exclude_middle_name_initial = False
-
-        CONSTANTS.force_exclude_first_name_initial = True
-        self.m(hn.initials_list(), ["A", "K", "D"], hn)
-        self.m(hn.initials_list(exclude_last_name=True), ["A", "K"], hn)
-        self.m(hn.initials_list(exclude_middle_name=True), ["D"], hn)
-        self.m(hn.initials_list(exclude_first_name=True), ["A", "K", "D"], hn)
-        CONSTANTS.force_exclude_first_name_initial = False
 
 
 TEST_NAMES = (

--- a/tests.py
+++ b/tests.py
@@ -2472,6 +2472,7 @@ if __name__ == '__main__':
         print((repr(hn_instance)))
         hn_instance.capitalize()
         print((repr(hn_instance)))
+        print("Initials: " + hn_instance.initials())
     else:
         print("-"*80)
         print("Running tests")

--- a/tests.py
+++ b/tests.py
@@ -2187,6 +2187,18 @@ class InitialsTestCase(HumanNameTestBase):
         hn = HumanName("Andrew Boris Petersen")
         self.m(hn.initials(), "A. B. P.", hn)
 
+    def test_initials_simple_name(self):
+        hn = HumanName("John Doe")
+        self.m(hn.initials(), "J. D.", hn)
+        hn = HumanName("John Doe", initials_format="{first} {last}")
+        self.m(hn.initials(), "J. D.", hn)
+        hn = HumanName("John Doe", initials_format="{last}")
+        self.m(hn.initials(), "D.", hn)
+        hn = HumanName("John Doe", initials_format="{first}")
+        self.m(hn.initials(), "J.", hn)
+        hn = HumanName("John Doe", initials_format="{middle}")
+        self.m(hn.initials(), "", hn)
+
     def test_initials_complex_name(self):
         hn = HumanName("Doe, John A. Kenneth, Jr.")
         self.m(hn.initials(), "J. A. K. D.", hn)
@@ -2203,14 +2215,14 @@ class InitialsTestCase(HumanNameTestBase):
 
     def test_initials_format_constants(self):
         from nameparser.config import CONSTANTS
-        orig_format = CONSTANTS.initials_format
+        _orig = CONSTANTS.initials_format
         CONSTANTS.initials_format = "{first} {last}"
         hn = HumanName("Doe, John A. Kenneth, Jr.")
         self.m(hn.initials(), "J. D.", hn)
         CONSTANTS.initials_format = "{first}  {last}"
         hn = HumanName("Doe, John A. Kenneth, Jr.")
-        self.m(hn.initials(), "J.  D.", hn)
-        CONSTANTS.initials_format = orig_format
+        self.m(hn.initials(), "J. D.", hn)
+        CONSTANTS.initials_format = _orig
 
     def test_initials_delimiter(self):
         hn = HumanName("Doe, John A. Kenneth, Jr.", initials_delimiter=";")
@@ -2218,11 +2230,11 @@ class InitialsTestCase(HumanNameTestBase):
 
     def test_initials_delimiter_constants(self):
         from nameparser.config import CONSTANTS
-        orig_delimiter = CONSTANTS.initials_delimiter
+        _orig = CONSTANTS.initials_delimiter
         CONSTANTS.initials_delimiter = ";"
         hn = HumanName("Doe, John A. Kenneth, Jr.")
         self.m(hn.initials(), "J; A; K; D;", hn)
-        CONSTANTS.initials_delimiter = orig_delimiter
+        CONSTANTS.initials_delimiter = _orig
 
     def test_initials_list(self):
         hn = HumanName("Andrew Boris Petersen")


### PR DESCRIPTION
Initials can be quite important when comparing two names in order to determine whether they are the same or not.
I have added a property to HumanName called `initials` which holds the first letters of the first name and the middle names. The list-version of the property is a list of single characters. The string-version is build from the list and has a dot and space after each character.

Some examples:
```
>>> HumanName("John Doe")
<HumanName : [
	title: '' 
	initials: 'J.' 
	first: 'John' 
	middle: '' 
	last: 'Doe' 
	suffix: ''
	nickname: ''
]>
>>> HumanName("Dr. Juan Q. Xavier Velasquez y Garcia")
<HumanName : [
	title: 'Dr.' 
	initials: 'J. Q. X.' 
	first: 'Juan' 
	middle: 'Q. Xavier' 
	last: 'Velasquez y Garcia' 
	suffix: ''
	nickname: ''
]>
>>> HumanName("Doe, John Boris D.")
<HumanName : [
	title: '' 
	initials: 'J. B. D.' 
	first: 'John' 
	middle: 'Boris D.' 
	last: 'Doe' 
	suffix: ''
	nickname: ''
]>
>>> HumanName("Doe, John Boris D.").initials
'J. B. D.'
>>> HumanName("Doe, John Boris D.").initials_list
['J', 'B', 'D']
```

Since the property is derived from the first and middle names, it will not be counted in the `len` function nor will it be displayed in the `str` function.

Each time the first or middle names are updated using the setter, the initials are updated as well. The initial creation of the initials is executed in the `post_process` phase. 

I have added tests and updated the documentation where needed. 

I hope this pull request is in line with the quality requirements and vision of the library. The changes should be backwards compatible, but please let me know if I have missed anything!