### PR TITLE
fix HumanName repr for names with single quotes

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -150,7 +150,7 @@ class HumanName(object):
         if self.unparsable:
             _string = "<%(class)s : [ Unparsable ] >" % {'class': self.__class__.__name__, }
         else:
-            _string = "<%(class)s : [\n\ttitle: '%(title)s' \n\tfirst: '%(first)s' \n\tmiddle: '%(middle)s' \n\tlast: '%(last)s' \n\tsuffix: '%(suffix)s'\n\tnickname: '%(nickname)s'\n]>" % {
+            _string = "<%(class)s : [\n\ttitle: %(title)r \n\tfirst: %(first)r \n\tmiddle: %(middle)r \n\tlast: %(last)r \n\tsuffix: %(suffix)r\n\tnickname: %(nickname)r\n]>" % {
                 'class': self.__class__.__name__,
                 'title': self.title or '',
                 'first': self.first or '',


### PR DESCRIPTION
eg `HumanName("O'NEILL")` would before this change return 
```
<HumanName : [
	title: ''
	first: 'O'Neill'
	middle: ''
	last: ''
	suffix: ''
	nickname: ''
]>
``` 
and with the change it will be:
```
<HumanName : [
	title: ''
	first: "O'Neill"
	middle: ''
	last: ''
	suffix: ''
	nickname: ''
]>
```

I think it can be further improved by dropping manual multiline formatting etc, let me know if you would accept that as well. 