### PR TITLE
Fix case when we have two same prefixes in the name

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -906,7 +906,7 @@ class HumanName(object):
                         # If it's the first piece and there are more than 1 rootnames, assume it's a first name
                         continue
                     next_prefix = next(iter(filter(self.is_prefix, pieces[i + 1:])))
-                    j = pieces.index(next_prefix, i+1)
+                    j = pieces.index(next_prefix, i + 1)
                     if j == i + 1:
                         # if there are two prefixes in sequence, join to the following piece
                         j += 1

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -36,10 +36,10 @@ class HumanName(object):
 
     Instantiation assigns to ``full_name``, and assignment to
     :py:attr:`full_name` triggers :py:func:`parse_full_name`. After parsing the
-    name, these instance attributes are available. Alternatively, you can pass 
+    name, these instance attributes are available. Alternatively, you can pass
     any of the instance attributes to the constructor method and skip the parsing
-    process. If any of the the instance attributes are passed to the constructor 
-    as keywords, :py:func:`parse_full_name` will not be performed. 
+    process. If any of the the instance attributes are passed to the constructor
+    as keywords, :py:func:`parse_full_name` will not be performed.
 
     **HumanName Instance Attributes**
 
@@ -536,9 +536,9 @@ class HumanName(object):
         Loops through 3 :py:data:`~nameparser.config.regexes.REGEXES`;
         `quoted_word`, `double_quotes` and `parenthesis`.
         """
-        
+
         empty_re = re.compile("")
-        
+
         re_quoted_word = self.C.regexes.quoted_word or empty_re
         re_double_quotes = self.C.regexes.double_quotes or empty_re
         re_parenthesis = self.C.regexes.parenthesis or empty_re
@@ -906,7 +906,7 @@ class HumanName(object):
                         # If it's the first piece and there are more than 1 rootnames, assume it's a first name
                         continue
                     next_prefix = next(iter(filter(self.is_prefix, pieces[i + 1:])))
-                    j = pieces.index(next_prefix)
+                    j = pieces.index(next_prefix, i+1)
                     if j == i + 1:
                         # if there are two prefixes in sequence, join to the following piece
                         j += 1

--- a/tests.py
+++ b/tests.py
@@ -2072,9 +2072,10 @@ class TitleTestCase(HumanNameTestBase):
         self.m(hn.last, "van der Velt", hn)
 
     def test_2_same_prefixes_in_the_name(self):
-        hh = HumanName("Van Ma Van")
-        self.m(hh.first, "Van Ma", hh)
-        self.m(hh.last, "Van", hh)
+        hh = HumanName("Vincent van Gogh van Beethoven")
+        self.m(hh.first, "Vincent", hh)
+        self.m(hh.middle, "van Gogh", hh)
+        self.m(hh.last, "van Beethoven", hh)
 
 class HumanNameCapitalizationTestCase(HumanNameTestBase):
     def test_capitalization_exception_for_III(self):

--- a/tests.py
+++ b/tests.py
@@ -2071,6 +2071,10 @@ class TitleTestCase(HumanNameTestBase):
         self.m(hn.first, "Mike", hn)
         self.m(hn.last, "van der Velt", hn)
 
+    def test_prefix_as_fist_name(self):
+        hh = HumanName("Van Ma Van")
+        self.m(hh.first, "Van Ma", hh)
+        self.m(hh.last, "Van", hh)
 
 class HumanNameCapitalizationTestCase(HumanNameTestBase):
     def test_capitalization_exception_for_III(self):
@@ -2343,12 +2347,12 @@ class InitialsTestCase(HumanNameTestBase):
     def test_initials_with_prefix(self):
         hn = HumanName("Alex van Johnson")
         self.m(hn.initials_list(), ["A", "J"], hn)
-        
+
     def test_constructor_first(self):
         hn = HumanName(first="TheName")
         self.assertFalse(hn.unparsable)
         self.m(hn.first, "TheName", hn)
-    
+
     def test_constructor_middle(self):
         hn = HumanName(middle="TheName")
         self.assertFalse(hn.unparsable)
@@ -2380,7 +2384,7 @@ class InitialsTestCase(HumanNameTestBase):
         self.m(hn.first, "TheName", hn)
         self.m(hn.last, "lastname", hn)
         self.m(hn.title, "mytitle", hn)
-    
+
 
 TEST_NAMES = (
     "John Doe",

--- a/tests.py
+++ b/tests.py
@@ -2071,7 +2071,7 @@ class TitleTestCase(HumanNameTestBase):
         self.m(hn.first, "Mike", hn)
         self.m(hn.last, "van der Velt", hn)
 
-    def test_prefix_as_fist_name(self):
+    def test_2_same_prefixes_in_the_name(self):
         hh = HumanName("Van Ma Van")
         self.m(hh.first, "Van Ma", hh)
         self.m(hh.last, "Van", hh)


### PR DESCRIPTION
Fix case when we have two same prefixes in the name

Previous behaviour: 
```
>>> from nameparser import HumanName
>>> HumanName("van ma van").as_dict()
{'title': '', 'first': ' ', 'middle': 'van ma', 'last': 'van', 'suffix': '', 'nickname': ''}
```
Fixed behaviour: 
```
>>> from nameparser import HumanName
>>> HumanName("van ma van").as_dict()
{'title': '', 'first': 'van ma', 'middle': '', 'last': 'van', 'suffix': '', 'nickname': ''}

```