### PR TITLE
Fix leading space in surnames after capitalize() with empty middle name

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -984,10 +984,10 @@ class HumanName:
 
         if not force and not (name == name.upper() or name == name.lower()):
             return
-        self.title_list = self.cap_piece(self.title, 'title').split(' ')
-        self.first_list = self.cap_piece(self.first, 'first').split(' ')
-        self.middle_list = self.cap_piece(self.middle, 'middle').split(' ')
-        self.last_list = self.cap_piece(self.last, 'last').split(' ')
+        self.title_list = self.cap_piece(self.title, 'title').split()
+        self.first_list = self.cap_piece(self.first, 'first').split()
+        self.middle_list = self.cap_piece(self.middle, 'middle').split()
+        self.last_list = self.cap_piece(self.last, 'last').split()
         self.suffix_list = self.cap_piece(self.suffix, 'suffix').split(', ')
 
     def handle_capitalization(self) -> None:

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -989,7 +989,7 @@ class HumanName:
         self.middle_list = self.cap_piece(self.middle, 'middle').split()
         self.last_list = self.cap_piece(self.last, 'last').split()
         # suffix is stored comma-separated ("Ph.D., J.D."), not space-separated
-        self.suffix_list = self.cap_piece(self.suffix, 'suffix').split(', ')
+        self.suffix_list = [s for s in self.cap_piece(self.suffix, 'suffix').split(', ') if s]
 
     def handle_capitalization(self) -> None:
         """

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -988,6 +988,7 @@ class HumanName:
         self.first_list = self.cap_piece(self.first, 'first').split()
         self.middle_list = self.cap_piece(self.middle, 'middle').split()
         self.last_list = self.cap_piece(self.last, 'last').split()
+        # suffix is stored comma-separated ("Ph.D., J.D."), not space-separated
         self.suffix_list = self.cap_piece(self.suffix, 'suffix').split(', ')
 
     def handle_capitalization(self) -> None:

--- a/tests/test_capitalization.py
+++ b/tests/test_capitalization.py
@@ -76,6 +76,23 @@ class HumanNameCapitalizationTestCase(HumanNameTestBase):
         self.assertEqual(hn.middle_list, [])
         self.m(str(hn), 'Dr Doe', hn)
 
+    def test_capitalize_empty_suffix_produces_no_spurious_tokens(self) -> None:
+        # ''.split(', ') returns [''] just like ''.split(' ') did for the other
+        # attributes — an absent suffix should produce suffix_list == [], not [''].
+        hn = HumanName('JOHN DOE')
+        hn.capitalize()
+        self.assertEqual(hn.suffix_list, [])
+
+    def test_capitalize_single_suffix_still_works(self) -> None:
+        hn = HumanName('JOHN DOE PHD')
+        hn.capitalize()
+        self.assertEqual(hn.suffix_list, ['Ph.D.'])
+
+    def test_capitalize_multiple_suffixes_still_split_correctly(self) -> None:
+        hn = HumanName('JOHN DOE PHD MD')
+        hn.capitalize()
+        self.assertEqual(hn.suffix_list, ['Ph.D.', 'M.D.'])
+
     # Leaving already-capitalized names alone
     def test_no_change_to_mixed_chase(self) -> None:
         hn = HumanName('Shirley Maclaine')

--- a/tests/test_capitalization.py
+++ b/tests/test_capitalization.py
@@ -40,27 +40,41 @@ class HumanNameCapitalizationTestCase(HumanNameTestBase):
         hn.capitalize()
         self.m(str(hn), 'Scott E. Werner', hn)
 
-    def test_capitalize_empty_name_part_has_no_leading_space_in_surnames(self) -> None:
-        # capitalize() split each attribute with str.split(' '), which returns
-        # [''] (rather than []) for an empty string. That spurious element
-        # leaked into surnames_list (middle_list + last_list) and produced a
-        # leading space in the surnames property, e.g. ' Doe' instead of 'Doe'.
+    def test_capitalize_empty_middle_produces_no_leading_space_in_surnames(self) -> None:
+        # str.split(' ') on an empty string returns [''] rather than [], so an
+        # absent middle produced a spurious token that leaked into surnames_list
+        # and caused a leading space in the surnames property (' Doe' not 'Doe').
         hn = HumanName('john doe')
         hn.capitalize()
         self.m(hn.surnames, 'Doe', hn)
         self.assertEqual(hn.middle_list, [])
         self.assertEqual(hn.surnames_list, ['Doe'])
 
-        # force=True on a mixed-case name hits the same code path
+    def test_capitalize_force_empty_middle_produces_no_leading_space_in_surnames(self) -> None:
+        # Without force=True, capitalize() exits early for mixed-case names and
+        # never reaches the split lines. Confirm the fix covers that path too.
         hn = HumanName('Jane Doe')
         hn.capitalize(force=True)
         self.m(hn.surnames, 'Doe', hn)
         self.assertEqual(hn.middle_list, [])
 
-        # other empty attribute lists are also free of the spurious '' element
+    def test_capitalize_empty_attributes_produce_no_spurious_tokens(self) -> None:
+        # Confirm the fix extends beyond surnames: empty attribute lists are []
+        # not [''], and non-empty ones contain only real tokens.
+        hn = HumanName('Jane Doe')
+        hn.capitalize(force=True)
         self.assertEqual(hn.title_list, [])
         self.assertEqual(hn.first_list, ['Jane'])
         self.assertEqual(hn.last_list, ['Doe'])
+
+    def test_capitalize_title_and_last_only_no_spurious_tokens(self) -> None:
+        # title+last with no first or middle leaves first_list and middle_list
+        # both empty. All-caps triggers capitalize() without force=True.
+        hn = HumanName('DR DOE')
+        hn.capitalize()
+        self.assertEqual(hn.first_list, [])
+        self.assertEqual(hn.middle_list, [])
+        self.m(str(hn), 'Dr Doe', hn)
 
     # Leaving already-capitalized names alone
     def test_no_change_to_mixed_chase(self) -> None:

--- a/tests/test_capitalization.py
+++ b/tests/test_capitalization.py
@@ -40,6 +40,28 @@ class HumanNameCapitalizationTestCase(HumanNameTestBase):
         hn.capitalize()
         self.m(str(hn), 'Scott E. Werner', hn)
 
+    def test_capitalize_empty_name_part_has_no_leading_space_in_surnames(self) -> None:
+        # capitalize() split each attribute with str.split(' '), which returns
+        # [''] (rather than []) for an empty string. That spurious element
+        # leaked into surnames_list (middle_list + last_list) and produced a
+        # leading space in the surnames property, e.g. ' Doe' instead of 'Doe'.
+        hn = HumanName('john doe')
+        hn.capitalize()
+        self.m(hn.surnames, 'Doe', hn)
+        self.assertEqual(hn.middle_list, [])
+        self.assertEqual(hn.surnames_list, ['Doe'])
+
+        # force=True on a mixed-case name hits the same code path
+        hn = HumanName('Jane Doe')
+        hn.capitalize(force=True)
+        self.m(hn.surnames, 'Doe', hn)
+        self.assertEqual(hn.middle_list, [])
+
+        # other empty attribute lists are also free of the spurious '' element
+        self.assertEqual(hn.title_list, [])
+        self.assertEqual(hn.first_list, ['Jane'])
+        self.assertEqual(hn.last_list, ['Doe'])
+
     # Leaving already-capitalized names alone
     def test_no_change_to_mixed_chase(self) -> None:
         hn = HumanName('Shirley Maclaine')


### PR DESCRIPTION
## Summary

After `capitalize()` is called on a name with any absent attribute, the corresponding `*_list` attribute becomes `['']` instead of `[]`. The most visible symptom is a spurious **leading space** in `surnames` (e.g. `' Doe'` instead of `'Doe'`). The same class of bug also affects `suffix_list`.

## Reproduction

```python
from nameparser import HumanName

n = HumanName('john doe')
n.capitalize()

print(repr(n.surnames))     # ' Doe'   <- leading space
print(n.middle_list)        # ['']    <- should be []
print(n.title_list)         # ['']    <- should be []
print(n.suffix_list)        # ['']    <- should be [] (no suffix present)
```

The leading space is a real observable artifact, not just an empty-list detail: downstream code that joins or compares surnames silently breaks.

## Cause

`cap_piece(...)` returns `''` for an absent name part. Splitting an empty string with an explicit separator always preserves a spurious empty token:

- `''.split(' ')` → `['']`
- `''.split(', ')` → `['']`

whereas `str.split()` with no argument returns `[]` for an empty string.

## Fix

### Whitespace-delimited attributes (`title`, `first`, `middle`, `last`)

Drop the explicit separator — bare `.split()` correctly returns `[]` for an empty string:

```diff
-        self.title_list = self.cap_piece(self.title, 'title').split(' ')
-        self.first_list = self.cap_piece(self.first, 'first').split(' ')
-        self.middle_list = self.cap_piece(self.middle, 'middle').split(' ')
-        self.last_list = self.cap_piece(self.last, 'last').split(' ')
+        self.title_list = self.cap_piece(self.title, 'title').split()
+        self.first_list = self.cap_piece(self.first, 'first').split()
+        self.middle_list = self.cap_piece(self.middle, 'middle').split()
+        self.last_list = self.cap_piece(self.last, 'last').split()
```

### Suffix

`suffix_list` must keep its comma delimiter (suffixes are stored as `"Ph.D., M.D."`), so bare `.split()` can't be used. Instead, filter empty tokens after splitting:

```diff
-        self.suffix_list = self.cap_piece(self.suffix, 'suffix').split(', ')
+        self.suffix_list = [s for s in self.cap_piece(self.suffix, 'suffix').split(', ') if s]
```

## Tests

- Split the original regression test into three focused methods (normal path, `force=True` path, list invariants)
- Added `test_capitalize_title_and_last_only_no_spurious_tokens` — exercises empty `first_list` and `middle_list` simultaneously
- Added three suffix tests: empty suffix → `[]`, single suffix, multiple suffixes

Full suite: 686 tests OK (20 expected failures).