### PR TITLE
Fix pickle/copy round-trip bugs in Constants and config managers

### DIFF
--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -138,7 +138,11 @@ class TupleManager(dict[str, T]):
         self.update(state)
 
     def __reduce__(self) -> tuple[type, tuple[()], Mapping[str, T]]:
-        return (TupleManager, (), self.__getstate__())
+        # Use type(self), not TupleManager, so subclasses such as
+        # RegexTupleManager survive a pickle round-trip instead of being
+        # downgraded to a plain TupleManager (which loses the EMPTY_REGEX
+        # default for unknown keys).
+        return (type(self), (), self.__getstate__())
 
 
 class RegexTupleManager(TupleManager[re.Pattern[str]]):

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -126,6 +126,13 @@ class TupleManager(dict[str, T]):
     '''
 
     def __getattr__(self, attr: str) -> T | None:
+        # Dunder names are Python's protocol probes (copy looks up __deepcopy__,
+        # inspect.unwrap looks up __wrapped__, ...), never config keys. Report
+        # them as genuinely absent so hasattr() is honest and those probes work;
+        # otherwise the dict default is mistaken for a real protocol hook. See
+        # RegexTupleManager.__getattr__ for the concrete failure this prevents.
+        if attr.startswith("__") and attr.endswith("__"):
+            raise AttributeError(attr)
         return self.get(attr)
 
     __setattr__ = dict.__setitem__

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -274,11 +274,22 @@ class Constants:
         return "<Constants() instance>"
 
     def __setstate__(self, state: Mapping[str, Any]) -> None:
-        Constants.__init__(self, state)
+        # Restore each saved attribute directly. The previous implementation
+        # passed the whole state dict to __init__ as the ``prefixes`` argument,
+        # which silently reverted every collection to its module default on
+        # unpickling.
+        self._pst = None
+        for name, value in state.items():
+            setattr(self, name, value)
 
     def __getstate__(self) -> Mapping[str, Any]:
-        attrs = [x for x in dir(self) if not x.startswith('_')]
-        return dict([(a, getattr(self, a)) for a in attrs])
+        # Pickle only the instance's own configuration: the collections built in
+        # __init__ plus any instance-level scalar overrides. Class-level scalar
+        # defaults are restored by the class itself, and underscore-prefixed
+        # names such as the ``_pst`` cache are private and rebuilt on demand.
+        # The computed ``suffixes_prefixes_titles`` property must not be
+        # serialized — it has no setter and would break __setstate__.
+        return {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
 
 
 #: A module-level instance of the :py:class:`Constants()` class.

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -280,6 +280,16 @@ class Constants:
         # unpickling.
         self._pst = None
         for name, value in state.items():
+            # Migration shim: pickles written before this fix used a dir() sweep
+            # for __getstate__, so their state carries the read-only
+            # ``suffixes_prefixes_titles`` property. Skip any such computed
+            # property rather than raising AttributeError on its missing setter;
+            # the real config is restored from the other keys. We don't promise
+            # to read pre-fix blobs forever — this only smooths migration for
+            # anyone persisting them, and can be dropped a release or two after
+            # 1.2.1 once they've re-pickled.
+            if isinstance(getattr(type(self), name, None), property):
+                continue
             setattr(self, name, value)
 
     def __getstate__(self) -> Mapping[str, Any]:
@@ -287,8 +297,9 @@ class Constants:
         # __init__ plus any instance-level scalar overrides. Class-level scalar
         # defaults are restored by the class itself, and underscore-prefixed
         # names such as the ``_pst`` cache are private and rebuilt on demand.
-        # The computed ``suffixes_prefixes_titles`` property must not be
-        # serialized — it has no setter and would break __setstate__.
+        # Filtering on ``self.__dict__`` also excludes the computed
+        # ``suffixes_prefixes_titles`` property automatically, since properties
+        # live on the class and never appear in an instance's ``__dict__``.
         return {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
 
 

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -147,6 +147,13 @@ class TupleManager(dict[str, T]):
 
 class RegexTupleManager(TupleManager[re.Pattern[str]]):
     def __getattr__(self, attr: str) -> re.Pattern[str]:
+        # Dunder names are Python's protocol probes (copy.deepcopy looks up
+        # __deepcopy__, inspect.unwrap looks up __wrapped__, ...), never regex
+        # keys. Report them as genuinely absent; otherwise the EMPTY_REGEX
+        # default is mistaken for a real protocol hook — e.g. copy.deepcopy
+        # tries to call the returned re.Pattern and raises TypeError.
+        if attr.startswith("__") and attr.endswith("__"):
+            raise AttributeError(attr)
         return self.get(attr, EMPTY_REGEX)
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -38,3 +38,6 @@ class HumanNameTestBase(Generic[T]):
 
     def assertIn(self, member: object, container: object, msg: object = None) -> None:
         assert member in container, msg  # type: ignore[operator]
+
+    def assertNotIn(self, member: object, container: object, msg: object = None) -> None:
+        assert member not in container, msg  # type: ignore[operator]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,9 @@
+import copy
 from collections.abc import Iterator
 
 import pytest
 
-from nameparser.config import CONSTANTS, SetManager, TupleManager
-
-ConfigCollection = SetManager | TupleManager
+from nameparser.config import CONSTANTS
 
 # Scalar (non-collection) config attributes that individual tests mutate on the
 # global CONSTANTS singleton. Several tests change these without restoring them;
@@ -38,20 +37,6 @@ _COLLECTION_CONFIG_ATTRS = (
 )
 
 
-def _clone_config_collection(value: ConfigCollection) -> ConfigCollection:
-    """Return an independent copy of a config collection manager.
-
-    ``copy.deepcopy`` is not used because ``RegexTupleManager`` carries compiled
-    patterns that its ``__reduce__`` cannot round-trip. Rebuilding from the
-    manager's own contents copies the container while sharing the (immutable)
-    elements, which is all the snapshot needs.
-    """
-    if isinstance(value, SetManager):
-        return SetManager(set(value))
-    # TupleManager / RegexTupleManager are dict subclasses.
-    return type(value)(dict(value))
-
-
 @pytest.fixture(autouse=True, params=['', None], ids=['default', 'none'])
 def empty_attribute_default(request: pytest.FixtureRequest) -> Iterator[str | None]:
     """Run every test under both empty_attribute_default settings, isolating global config.
@@ -66,7 +51,7 @@ def empty_attribute_default(request: pytest.FixtureRequest) -> Iterator[str | No
     """
     scalar_snapshot = {attr: getattr(CONSTANTS, attr) for attr in _SCALAR_CONFIG_ATTRS}
     collection_snapshot = {
-        attr: _clone_config_collection(getattr(CONSTANTS, attr))
+        attr: copy.deepcopy(getattr(CONSTANTS, attr))
         for attr in _COLLECTION_CONFIG_ATTRS
     }
     CONSTANTS.empty_attribute_default = request.param

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,3 +1,4 @@
+import copy
 import pickle
 
 from nameparser import HumanName
@@ -158,6 +159,36 @@ class ConstantsCustomizationTests(HumanNameTestBase):
 
         self.assertEqual(type(restored.regexes), RegexTupleManager)
         self.assertEqual(restored.regexes.does_not_exist, EMPTY_REGEX)
+
+    def test_regexes_deepcopy_roundtrip(self) -> None:
+        """copy.deepcopy of a RegexTupleManager must round-trip.
+
+        __getattr__ answered every unknown name with the EMPTY_REGEX default,
+        including the __deepcopy__ probe copy.deepcopy issues. copy then
+        mistook that re.Pattern for a deep-copy hook and tried to call it.
+        """
+        c = Constants()
+
+        dup = copy.deepcopy(c.regexes)
+
+        self.assertEqual(type(dup), RegexTupleManager)
+        self.assertEqual(dict(dup), dict(c.regexes))
+        # The EMPTY_REGEX default still applies to genuinely unknown keys.
+        self.assertEqual(dup.does_not_exist, EMPTY_REGEX)
+
+    def test_regextuplemanager_ignores_dunder_lookups(self) -> None:
+        """Unknown dunder names report as absent, not as the EMPTY_REGEX default.
+
+        Dunder names are Python's protocol probes (copy.deepcopy looks up
+        __deepcopy__, inspect.unwrap looks up __wrapped__, ...), never config
+        keys. Answering them with a regex breaks that machinery.
+        """
+        c = Constants()
+        sentinel = object()
+
+        self.assertEqual(getattr(c.regexes, '__deepcopy__', sentinel), sentinel)
+        # A normal (non-dunder) unknown key still yields the EMPTY_REGEX default.
+        self.assertEqual(c.regexes.unknown_key, EMPTY_REGEX)
 
     def test_unpickle_legacy_state_with_property_key(self) -> None:
         """Pickles written by older versions must still load.

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,7 +1,7 @@
 import pickle
 
 from nameparser import HumanName
-from nameparser.config import Constants
+from nameparser.config import Constants, SetManager
 
 from tests.base import HumanNameTestBase
 
@@ -128,6 +128,9 @@ class ConstantsCustomizationTests(HumanNameTestBase):
         # The contributing collections must match the original exactly.
         self.assertEqual(set(restored.titles), set(c.titles))
         self.assertEqual(set(restored.prefixes), set(c.prefixes))
+        # The collections must also keep their manager type, not just contents.
+        self.assertEqual(type(restored.titles), SetManager)
+        self.assertEqual(type(restored.prefixes), SetManager)
 
     def test_pickle_roundtrip_preserves_instance_scalar_override(self) -> None:
         """An instance-level scalar override must survive a pickle round-trip."""
@@ -138,3 +141,29 @@ class ConstantsCustomizationTests(HumanNameTestBase):
         restored = pickle.loads(pickle.dumps(c))
 
         self.assertEqual(restored.empty_attribute_default, None)
+
+    def test_unpickle_legacy_state_with_property_key(self) -> None:
+        """Pickles written by older versions must still load.
+
+        The previous __getstate__ built its state from a dir() sweep, which
+        always included the computed `suffixes_prefixes_titles` property (no
+        customization required). That property has no setter, so __setstate__
+        must skip such keys instead of raising AttributeError.
+
+        Covers the temporary migration shim in __setstate__; remove this test
+        when that shim is dropped (a release or two after 1.2.1).
+        """
+        c = Constants()
+        c.titles.add('legacytitle')
+        # Reproduce the legacy dir()-sweep state dict, which carries the
+        # read-only `suffixes_prefixes_titles` property alongside the real config.
+        legacy_state = {
+            name: getattr(c, name) for name in dir(c) if not name.startswith('_')
+        }
+        self.assertIn('suffixes_prefixes_titles', legacy_state)
+
+        restored = Constants.__new__(Constants)
+        restored.__setstate__(legacy_state)
+
+        # The real customization is recovered and the property key is ignored.
+        self.assertIn('legacytitle', restored.titles)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,3 +1,5 @@
+import pickle
+
 from nameparser import HumanName
 from nameparser.config import Constants
 
@@ -104,3 +106,35 @@ class ConstantsCustomizationTests(HumanNameTestBase):
         c = Constants()
         c.titles.add_with_encoding(b'b\351ck', encoding='latin_1')
         self.assertIn('béck', c.titles)
+
+    def test_pickle_roundtrip_preserves_customizations(self) -> None:
+        """A pickled Constants must restore its customized collections.
+
+        Regression test: __setstate__ previously passed the whole state dict
+        to __init__ as the `prefixes` argument, so every collection silently
+        reverted to its module default on unpickling.
+        """
+        c = Constants()
+        c.titles.add('customtitle')
+        c.prefixes.add('customprefix')
+        c.titles.remove('hon')
+
+        # Safe: round-tripping a Constants the test just built, not untrusted data.
+        restored = pickle.loads(pickle.dumps(c))
+
+        self.assertIn('customtitle', restored.titles)
+        self.assertIn('customprefix', restored.prefixes)
+        self.assertNotIn('hon', restored.titles)
+        # The contributing collections must match the original exactly.
+        self.assertEqual(set(restored.titles), set(c.titles))
+        self.assertEqual(set(restored.prefixes), set(c.prefixes))
+
+    def test_pickle_roundtrip_preserves_instance_scalar_override(self) -> None:
+        """An instance-level scalar override must survive a pickle round-trip."""
+        c = Constants()
+        c.empty_attribute_default = None
+
+        # Safe: round-tripping a Constants the test just built, not untrusted data.
+        restored = pickle.loads(pickle.dumps(c))
+
+        self.assertEqual(restored.empty_attribute_default, None)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -2,7 +2,7 @@ import copy
 import pickle
 
 from nameparser import HumanName
-from nameparser.config import Constants, RegexTupleManager, SetManager
+from nameparser.config import Constants, RegexTupleManager, SetManager, TupleManager
 from nameparser.config.regexes import EMPTY_REGEX
 
 from tests.base import HumanNameTestBase
@@ -189,6 +189,23 @@ class ConstantsCustomizationTests(HumanNameTestBase):
         self.assertEqual(getattr(c.regexes, '__deepcopy__', sentinel), sentinel)
         # A normal (non-dunder) unknown key still yields the EMPTY_REGEX default.
         self.assertEqual(c.regexes.unknown_key, EMPTY_REGEX)
+
+    def test_tuplemanager_ignores_dunder_lookups(self) -> None:
+        """Base TupleManager must report unknown dunder names as absent too.
+
+        It returned None for any missing attribute, so `hasattr(tm, '__x__')`
+        was always True — a landmine for any probe that does hasattr-then-call.
+        Guarding dunders keeps the base consistent with RegexTupleManager.
+        """
+        c = Constants()
+        tm = c.capitalization_exceptions  # a plain TupleManager
+        sentinel = object()
+
+        self.assertEqual(type(tm), TupleManager)
+        self.assertFalse(hasattr(tm, '__deepcopy__'))
+        self.assertEqual(getattr(tm, '__wrapped__', sentinel), sentinel)
+        # A normal (non-dunder) unknown key still returns the None default.
+        self.assertEqual(tm.unknown_key, None)
 
     def test_unpickle_legacy_state_with_property_key(self) -> None:
         """Pickles written by older versions must still load.

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,7 +1,8 @@
 import pickle
 
 from nameparser import HumanName
-from nameparser.config import Constants, SetManager
+from nameparser.config import Constants, RegexTupleManager, SetManager
+from nameparser.config.regexes import EMPTY_REGEX
 
 from tests.base import HumanNameTestBase
 
@@ -141,6 +142,22 @@ class ConstantsCustomizationTests(HumanNameTestBase):
         restored = pickle.loads(pickle.dumps(c))
 
         self.assertEqual(restored.empty_attribute_default, None)
+
+    def test_pickle_roundtrip_preserves_regex_manager_subclass(self) -> None:
+        """regexes must round-trip as a RegexTupleManager, not a plain TupleManager.
+
+        TupleManager.__reduce__ previously hardcoded TupleManager, so the
+        RegexTupleManager subclass was downgraded on unpickling. The difference
+        is observable: RegexTupleManager returns the EMPTY_REGEX default for an
+        unknown key, while a plain TupleManager returns None.
+        """
+        c = Constants()
+
+        # Safe: round-tripping a Constants the test just built, not untrusted data.
+        restored = pickle.loads(pickle.dumps(c))
+
+        self.assertEqual(type(restored.regexes), RegexTupleManager)
+        self.assertEqual(restored.regexes.does_not_exist, EMPTY_REGEX)
 
     def test_unpickle_legacy_state_with_property_key(self) -> None:
         """Pickles written by older versions must still load.

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1,3 +1,4 @@
+import pickle
 import re
 
 import pytest
@@ -44,6 +45,26 @@ class HumanNamePythonTests(HumanNameTestBase):
     def test_name_instance_pickle(self) -> None:
         hn = HumanName("Title First Middle Middle Last, Jr.")
         self.assertTrue(dill.pickles(hn))
+
+    def test_name_instance_pickle_preserves_instance_config(self) -> None:
+        """A HumanName carrying its own config must parse identically after a
+        pickle round-trip.
+
+        HumanName pickles its instance Constants (``.C``) through the default
+        __dict__ path, so a broken Constants round-trip silently produced a
+        differently-configured parser on the other side.
+        """
+        # Passing None as the second argument gives this name its own Constants.
+        hn = HumanName("Smith, Dr. John", None)
+        hn.C.titles.add('chancellor')
+        hn.parse_full_name()
+
+        # Safe: round-tripping a HumanName the test just built, not untrusted data.
+        restored = pickle.loads(pickle.dumps(hn))
+
+        self.assertIn('chancellor', restored.C.titles)
+        restored.full_name = "Chancellor Jane Smith"
+        self.assertEqual(restored.title, "Chancellor")
 
     def test_comparison(self) -> None:
         hn1 = HumanName("Doe-Ray, Dr. John P., CLU, CFP, LUTC")

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1,3 +1,4 @@
+import copy
 import pickle
 import re
 
@@ -65,6 +66,31 @@ class HumanNamePythonTests(HumanNameTestBase):
         self.assertIn('chancellor', restored.C.titles)
         restored.full_name = "Chancellor Jane Smith"
         self.assertEqual(restored.title, "Chancellor")
+
+    def test_name_instance_deepcopy(self) -> None:
+        """copy.deepcopy of a HumanName must round-trip.
+
+        HumanName has no custom copy hooks, so deepcopy recurses into its
+        Constants (`.C`), and previously into `.C.regexes`, whose __getattr__
+        answered copy's __deepcopy__ probe with a re.Pattern — making
+        deepcopy of *any* HumanName raise TypeError.
+        """
+        hn = HumanName("Dr. John P. Doe-Ray, CLU")
+
+        dup = copy.deepcopy(hn)
+
+        self.assertEqual(str(dup), str(hn))
+
+    def test_name_instance_deepcopy_isolates_instance_config(self) -> None:
+        """A deep-copied HumanName with its own config must be independent."""
+        hn = HumanName("Smith, Dr. John", None)
+        hn.C.titles.add('chancellor')
+
+        dup = copy.deepcopy(hn)
+        dup.C.titles.add('marker')
+
+        self.assertIn('chancellor', dup.C.titles)
+        self.assertNotIn('marker', hn.C.titles)
 
     def test_comparison(self) -> None:
         hn1 = HumanName("Doe-Ray, Dr. John P., CLU, CFP, LUTC")


### PR DESCRIPTION
## Problem

Closes #167.

The pickle/copy support for `Constants` and its config managers had several
round-trip bugs. They were silent: no exception, just a differently-configured
parser on the other side (or, for `deepcopy`, a confusing `TypeError`).

This also affects pickling a `HumanName` that carries its own instance config,
since `HumanName` pickles its `.C` via the default `__dict__` path.

**Minimal reproduction (on `master`):**

```python
import pickle
from nameparser.config import Constants

c = Constants()
c.titles.add('customtitle')
c.prefixes.add('customprefix')

r = pickle.loads(pickle.dumps(c))
print('customtitle'  in r.titles)    # False  (expected True)
print('customprefix' in r.prefixes)  # False  (expected True)
print(sorted(r.prefixes)[:3])
# ['capitalization_exceptions', 'capitalize_name', 'conjunctions']  <-- attribute names, not prefixes
```

## What's fixed

This PR bundles five related round-trip fixes, each in its own commit with a
regression test confirmed to fail before the fix.

### 1. Pickle round-trip discarded all `Constants` customizations

`__setstate__` passed the entire state dict to `__init__` as the first
positional argument (`prefixes`). Iterating a dict yields its **keys**, which is
why `prefixes` ended up holding attribute names; every other `__init__`
parameter fell back to its module default, discarding the pickled values.
`__getstate__` also used a `dir()` sweep that pulled in the computed
`suffixes_prefixes_titles` **property**, which has no setter.

- `__setstate__` now restores each saved attribute directly via `setattr` (and
  resets the `_pst` cache) instead of re-running `__init__`.
- `__getstate__` serializes only the instance's own configuration from
  `self.__dict__` (the `__init__` collections plus any instance-level scalar
  overrides), excluding underscore-prefixed private state. Filtering on
  `self.__dict__` excludes the computed property automatically, since properties
  live on the class.

### 2. Pre-fix pickles now load instead of raising

The old `dir()`-sweep `__getstate__` always stored the read-only
`suffixes_prefixes_titles` property in its state — for **every** instance,
customized or not. The new `__setstate__` would `setattr` that key and raise
`AttributeError` on its missing setter, so no pre-fix blob could be loaded.

`__setstate__` now skips computed properties on restore. This is an intentionally
**temporary migration shim** so anyone persisting pre-fix blobs has an easy
upgrade; it can be dropped a release or two after 1.2.1 once they've re-pickled.

### 3. `TupleManager` subclasses were downgraded on unpickling

`TupleManager.__reduce__` hardcoded `TupleManager` as the reconstruction
callable, so a `RegexTupleManager` came back as a plain `TupleManager`. The
difference is observable: `RegexTupleManager` returns `EMPTY_REGEX` for an
unknown key, while `TupleManager` returns `None`.

`__reduce__` now uses `type(self)` so subclasses round-trip as themselves.

### 4. `copy.deepcopy` of a `RegexTupleManager` raised `TypeError`

`RegexTupleManager.__getattr__` returned the `EMPTY_REGEX` default for **any**
unknown attribute, including the dunder names Python's machinery probes for.
`copy.deepcopy` does `getattr(obj, "__deepcopy__", None)` to detect a custom
deep-copy hook; it received `EMPTY_REGEX` (a truthy `re.Pattern`) instead of
`None`, then tried to call it → `re.Pattern object is not callable`. The same
trap applied to `copy.copy`, `inspect.unwrap`, and similar probes.

`__getattr__` now rejects dunder-shaped names with `AttributeError` so those
probes correctly see the attribute as absent. Non-dunder unknown keys still get
the `EMPTY_REGEX` default. With `deepcopy` now working, the
`_clone_config_collection` workaround in the test conftest (and its now-stale
comment) is replaced with `copy.deepcopy`.

This also repairs `copy.deepcopy(HumanName(...))`, which raised `TypeError` on
`master` for **every** name: `HumanName` has no custom copy hooks, so deepcopy
recurses into `.C.regexes` and hit this same probe.

### 5. Base `TupleManager` answered dunder probes too

`TupleManager.__getattr__` returned `None` for any missing attribute, so
`hasattr(tm, '__anydunder__')` was always `True`. `copy.deepcopy` tolerated this
(it reads `None` as "absent"), but any `hasattr`-then-call probe would break.

The base now applies the same dunder guard as `RegexTupleManager`, so the two
managers behave consistently and `hasattr` is honest. Non-dunder unknown keys
still return the `None` default.

## Tests

- `test_pickle_roundtrip_preserves_customizations` — added/removed titles and
  prefixes survive a round-trip, match the originals exactly, and keep their
  `SetManager` type.
- `test_pickle_roundtrip_preserves_instance_scalar_override` — an instance-level
  scalar override (`empty_attribute_default`) survives.
- `test_unpickle_legacy_state_with_property_key` — a pre-fix (`dir()`-sweep)
  state dict loads without raising (covers the migration shim).
- `test_pickle_roundtrip_preserves_regex_manager_subclass` — `regexes` returns
  as a `RegexTupleManager`, with the `EMPTY_REGEX` default for unknown keys.
- `test_regexes_deepcopy_roundtrip` — `copy.deepcopy(c.regexes)` round-trips
  with type, contents, and the default preserved.
- `test_regextuplemanager_ignores_dunder_lookups` — dunder probes report as
  absent; non-dunder unknown keys still yield `EMPTY_REGEX`.
- `test_tuplemanager_ignores_dunder_lookups` — the base `TupleManager` reports
  dunders as absent (`hasattr` is False); non-dunder unknown keys still return
  `None`.
- `test_name_instance_pickle_preserves_instance_config` — a `HumanName` carrying
  its own `.C` config keeps a custom title and parses accordingly after a
  pickle round-trip.
- `test_name_instance_deepcopy` / `test_name_instance_deepcopy_isolates_instance_config`
  — `copy.deepcopy(HumanName(...))` round-trips, and a deep-copied name with its
  own config is independent of the original.

The conftest's autouse snapshot fixture now `deepcopy`s the config managers on
every test, so the deepcopy fix is exercised across the whole suite.

Full suite: **706 passed, 20 xfailed**; `mypy` and `ruff` clean. The existing
`dill`-based pickle tests still pass.

## Out of scope (follow-up)

A default `HumanName` loses its `.C is CONSTANTS` singleton identity across a
round-trip (`has_own_config` flips to `True`, and each pickle carries a full
`Constants` copy). This is pre-existing and changes `HumanName` serialization
semantics, so it's tracked separately in #169.

---

This was prepared with the assistance of AI, under my direction and review.
