### PR TITLE
fix: add initials_separator; fix or-defaulting for format/delimiter kwargs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -203,8 +203,25 @@ Furthermore, the delimiter for the string output can be set through:
 
   >>> HumanName("Doe, John A. Kenneth, Jr.", initials_delimiter=";").initials()
   'J; A; K; D;'
-  >>> HumanName("Doe, John A. Kenneth, Jr.", initials_format="{first}{middle}{last}", initials_delimiter=".").initials()
-  'J.A. K.D.'
+
+The separator between consecutive initials *within* a name group (e.g. two middle
+names) is controlled by :py:attr:`~nameparser.config.Constants.initials_separator`,
+which defaults to ``" "``. Setting it to ``""`` removes that space.
+
+``initials_delimiter``, ``initials_separator``, and ``initials_format`` work together:
+
+- ``initials_delimiter`` — appended *after* each individual initial (default ``"."``)
+- ``initials_separator`` — placed *between* consecutive initials in the same group (default ``" "``)
+- ``initials_format`` — controls how the first, middle, and last groups are arranged
+
+For example, to produce compact period-separated initials with no spaces:
+
+.. doctest:: initials separator
+
+  >>> HumanName("Doe, John A. Kenneth, Jr.", initials_separator="", initials_format="{first}{middle}{last}").initials()
+  'J.A.K.D.'
+  >>> HumanName("Doe, John A. Kenneth, Jr.", initials_delimiter="", initials_separator="", initials_format="{first}{middle}{last}").initials()
+  'JAKD'
 
 To get a list representation of the initials, use :py:meth:`~nameparser.HumanName.initials_list`.
 This function is unaffected by :py:attr:`~nameparser.config.Constants.initials_format`

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -206,12 +206,13 @@ Furthermore, the delimiter for the string output can be set through:
 
 The separator between consecutive initials *within* a name group (e.g. two middle
 names) is controlled by :py:attr:`~nameparser.config.Constants.initials_separator`,
-which defaults to ``" "``. Setting it to ``""`` removes that space.
+which defaults to ``" "``. Setting it to ``""`` removes that space within a group;
+spacing *between* groups is still governed by ``initials_format``.
 
 ``initials_delimiter``, ``initials_separator``, and ``initials_format`` work together:
 
 - ``initials_delimiter`` — appended *after* each individual initial (default ``"."``)
-- ``initials_separator`` — placed *between* consecutive initials in the same group (default ``" "``)
+- ``initials_separator`` — placed *after* the delimiter between consecutive initials in the same group (default ``" "``), so with ``delimiter="."`` and ``separator=" "`` you get ``A. K.``
 - ``initials_format`` — controls how the first, middle, and last groups are arranged
 
 For example, to produce compact period-separated initials with no spaces:

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -223,7 +223,9 @@ class Constants:
 
     With defaults ``initials_delimiter="."`` and ``initials_separator=" "``,
     ``initials()`` produces ``"J. A. D."``. Setting ``initials_separator=""``
-    with ``initials_delimiter="."`` produces ``"J.A.D."``.
+    with ``initials_delimiter="."`` and ``initials_format="{first}{middle}{last}"``
+    produces ``"J.A.D."``. With the default ``initials_format``, group-level
+    spacing from the template is still applied.
     """
 
     empty_attribute_default = ''

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -215,6 +215,17 @@ class Constants:
     Will be used to add a delimiter between each initial.
     """
 
+    initials_separator = " "
+    """
+    The default separator placed between consecutive initials within a name
+    group (first, middle, or last). Distinct from ``initials_delimiter``,
+    which is the trailing character after each individual initial.
+
+    With defaults ``initials_delimiter="."`` and ``initials_separator=" "``,
+    ``initials()`` produces ``"J. A. D."``. Setting ``initials_separator=""``
+    with ``initials_delimiter="."`` produces ``"J.A.D."``.
+    """
+
     empty_attribute_default = ''
     """
     Default return value for empty attributes.

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -179,7 +179,7 @@ class HumanName:
             return getattr(self, self._members[c]) or next(self)
 
     def __str__(self) -> str:
-        if self.string_format:
+        if self.string_format is not None:
             # string_format = "{title} {first} {middle} {last} {suffix} ({nickname})"
             _s = self.string_format.format(**self.as_dict())
             # remove trailing punctuation from missing nicknames
@@ -243,7 +243,7 @@ class HumanName:
                 if not (self.is_prefix(part) or self.is_conjunction(part)) or firstname:
                     initials.append(part[0])
         if len(initials) > 0:
-            return self.C.initials_separator.join(initials)
+            return self.initials_separator.join(initials)
         else:
             return self.C.empty_attribute_default
 

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -94,6 +94,7 @@ class HumanName:
         string_format: str | None = None,
         initials_format: str | None = None,
         initials_delimiter: str | None = None,
+        initials_separator: str | None = None,
         first: str | list[str] | None = None,
         middle: str | list[str] | None = None,
         last: str | list[str] | None = None,
@@ -106,9 +107,10 @@ class HumanName:
             self.C = Constants()
 
         self.encoding = encoding
-        self.string_format = string_format or self.C.string_format
-        self.initials_format = initials_format or self.C.initials_format
-        self.initials_delimiter = initials_delimiter or self.C.initials_delimiter
+        self.string_format      = string_format      if string_format      is not None else self.C.string_format
+        self.initials_format    = initials_format    if initials_format    is not None else self.C.initials_format
+        self.initials_delimiter = initials_delimiter if initials_delimiter is not None else self.C.initials_delimiter
+        self.initials_separator = initials_separator if initials_separator is not None else self.C.initials_separator
         if (first or middle or last or title or suffix or nickname):
             self.first = first
             self.middle = middle
@@ -241,7 +243,7 @@ class HumanName:
                 if not (self.is_prefix(part) or self.is_conjunction(part)) or firstname:
                     initials.append(part[0])
         if len(initials) > 0:
-            return " ".join(initials)
+            return self.C.initials_separator.join(initials)
         else:
             return self.C.empty_attribute_default
 
@@ -265,19 +267,25 @@ class HumanName:
 
     def initials(self) -> str:
         """
-            Return period-delimited initials of the first, middle and optionally last name.
+        Return formatted initials for the name, controlled by
+        ``initials_format``, ``initials_delimiter``, and ``initials_separator``.
 
-            :param bool include_last_name: Include the last name as part of the initials
-            :rtype: str
+        ``initials_delimiter`` is appended after each individual initial.
+        ``initials_separator`` is placed between consecutive initials within
+        a name group (first, middle, or last). Both can be set as
+        ``Constants`` attributes or as ``HumanName`` constructor kwargs.
 
-            .. doctest::
+        .. doctest::
 
-                >>> name = HumanName("Sir Bob Andrew Dole")
-                >>> name.initials()
-                "B. A. D."
-                >>> name = HumanName("Sir Bob Andrew Dole", initials_format="{first} {middle}")
-                >>> name.initials()
-                "B. A."
+            >>> name = HumanName("Sir Bob Andrew Dole")
+            >>> name.initials()
+            "B. A. D."
+            >>> name = HumanName("Sir Bob Andrew Dole", initials_format="{first} {middle}")
+            >>> name.initials()
+            "B. A."
+            >>> name = HumanName("Doe, John A.", initials_delimiter="", initials_separator="")
+            >>> name.initials()
+            "J A D"
         """
 
         first_initials_list = [self.__process_initial__(name, True) for name in self.first_list if name]
@@ -289,11 +297,11 @@ class HumanName:
         # output. A fully-empty result falls back to empty_attribute_default,
         # matching the other attribute accessors (e.g. ``first``).
         initials_dict = {
-            "first":  (self.initials_delimiter + " ").join(first_initials_list) + self.initials_delimiter
+            "first":  (self.initials_delimiter + self.initials_separator).join(first_initials_list) + self.initials_delimiter
             if len(first_initials_list) else "",
-            "middle": (self.initials_delimiter + " ").join(middle_initials_list) + self.initials_delimiter
+            "middle": (self.initials_delimiter + self.initials_separator).join(middle_initials_list) + self.initials_delimiter
             if len(middle_initials_list) else "",
-            "last": (self.initials_delimiter + " ").join(last_initials_list) + self.initials_delimiter
+            "last": (self.initials_delimiter + self.initials_separator).join(last_initials_list) + self.initials_delimiter
             if len(last_initials_list) else ""
         }
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -39,6 +39,9 @@ class HumanNameTestBase(Generic[T]):
     def assertIn(self, member: object, container: object, msg: object = None) -> None:
         assert member in container, msg  # type: ignore[operator]
 
+    def assertNotEqual(self, first: object, second: object, msg: object = None) -> None:
+        assert first != second, msg
+
     def assertNotIn(self, member: object, container: object, msg: object = None) -> None:
         assert member not in container, msg  # type: ignore[operator]
 

--- a/tests/test_initials.py
+++ b/tests/test_initials.py
@@ -69,10 +69,12 @@ class InitialsTestCase(HumanNameTestBase):
     def test_initials_delimiter_constants(self) -> None:
         from nameparser.config import CONSTANTS
         _orig = CONSTANTS.initials_delimiter
-        CONSTANTS.initials_delimiter = ";"
-        hn = HumanName("Doe, John A. Kenneth, Jr.")
-        self.m(hn.initials(), "J; A; K; D;", hn)
-        CONSTANTS.initials_delimiter = _orig
+        try:
+            CONSTANTS.initials_delimiter = ";"
+            hn = HumanName("Doe, John A. Kenneth, Jr.")
+            self.m(hn.initials(), "J; A; K; D;", hn)
+        finally:
+            CONSTANTS.initials_delimiter = _orig
 
     def test_initials_separator_default_on_constants(self) -> None:
         from nameparser.config import CONSTANTS
@@ -103,10 +105,10 @@ class InitialsTestCase(HumanNameTestBase):
         # Regression: initials_format='' was silently ignored due to `or` defaulting
         hn = HumanName("Doe, John A.")
         hn2 = HumanName("Doe, John A.", initials_format="")
-        assert hn.initials() != hn2.initials()
-        # When format is empty string, result should be either "" or empty_attribute_default
-        result = hn2.initials()
-        assert result == "" or result == hn2.C.empty_attribute_default
+        self.assertNotEqual(hn.initials(), hn2.initials())
+        # "".format(...) returns ""; collapse_whitespace returns "" which falls through
+        # to empty_attribute_default (may be "" or None depending on config variant).
+        self.assertFalse(hn2.initials())
 
     def test_initials_separator_kwarg(self) -> None:
         # initials_separator="" with initials_format="{first}{middle}{last}" gives
@@ -117,6 +119,20 @@ class InitialsTestCase(HumanNameTestBase):
             initials_format="{first}{middle}{last}",
         )
         self.m(hn.initials(), "J.A.K.D.", hn)
+
+    def test_initials_separator_custom_value(self) -> None:
+        # Non-empty custom separator exercising __process_initial__ on a multi-word
+        # token. "Van Berg" is a single name part whose two words produce two initials
+        # joined by initials_separator.
+        hn = HumanName("", initials_separator="-", initials_delimiter=".")
+        result = hn.__process_initial__("Van Berg", firstname=True)
+        self.assertEqual(result, "V-B")
+
+    def test_str_default_behavior_unchanged(self) -> None:
+        # Regression guard for the `or` → `is not None` change in __str__:
+        # the default path (no string_format kwarg) must still produce the expected string.
+        hn = HumanName("John Doe")
+        self.assertEqual(str(hn), "John Doe")
 
     def test_constructor_first(self) -> None:
         hn = HumanName(first="TheName")
@@ -167,15 +183,6 @@ class InitialsTestCase(HumanNameTestBase):
         hn = HumanName("John Doe", string_format="")
         self.assertEqual(str(hn), "")
 
-    def test_initials_separator_multiword_name_part(self) -> None:
-        # __process_initial__ splits on spaces internally for multi-word tokens;
-        # initials_separator must flow through there too.
-        hn = HumanName("", constants=None)
-        hn.initials_separator = ""
-        # Directly exercise __process_initial__ with a two-word part
-        result = hn.__process_initial__("Van Berg", firstname=True)
-        self.assertEqual(result, "VB")
-
     def test_initials_separator_empty_multi_part_middle(self) -> None:
         # Full workflow from issue #152: empty delimiter + separator + compact format
         # gives fully concatenated initials with no spaces or punctuation.
@@ -193,11 +200,13 @@ class InitialsTestCase(HumanNameTestBase):
         _orig_d = CONSTANTS.initials_delimiter
         _orig_s = CONSTANTS.initials_separator
         _orig_f = CONSTANTS.initials_format
-        CONSTANTS.initials_delimiter = ""
-        CONSTANTS.initials_separator = ""
-        CONSTANTS.initials_format = "{first}{middle}{last}"
-        hn = HumanName("Doe, John A. Kenneth")
-        self.m(hn.initials(), "JAKD", hn)
-        CONSTANTS.initials_delimiter = _orig_d
-        CONSTANTS.initials_separator = _orig_s
-        CONSTANTS.initials_format = _orig_f
+        try:
+            CONSTANTS.initials_delimiter = ""
+            CONSTANTS.initials_separator = ""
+            CONSTANTS.initials_format = "{first}{middle}{last}"
+            hn = HumanName("Doe, John A. Kenneth")
+            self.m(hn.initials(), "JAKD", hn)
+        finally:
+            CONSTANTS.initials_delimiter = _orig_d
+            CONSTANTS.initials_separator = _orig_s
+            CONSTANTS.initials_format = _orig_f

--- a/tests/test_initials.py
+++ b/tests/test_initials.py
@@ -155,11 +155,23 @@ class InitialsTestCase(HumanNameTestBase):
         self.m(hn.last, "lastname", hn)
         self.m(hn.title, "mytitle", hn)
 
+    def test_initials_separator_kwarg_multiword_part(self) -> None:
+        # Regression: initials_separator kwarg must flow into __process_initial__
+        # for multi-word name parts, not just into the initials() join calls.
+        hn = HumanName("", initials_separator="")
+        result = hn.__process_initial__("Van Berg", firstname=True)
+        self.assertEqual(result, "VB")
+
+    def test_string_format_empty_string_kwarg(self) -> None:
+        # Regression: string_format='' was silently ignored due to `or` defaulting
+        hn = HumanName("John Doe", string_format="")
+        self.assertEqual(str(hn), "")
+
     def test_initials_separator_multiword_name_part(self) -> None:
         # __process_initial__ splits on spaces internally for multi-word tokens;
         # initials_separator must flow through there too.
         hn = HumanName("", constants=None)
-        hn.C.initials_separator = ""
+        hn.initials_separator = ""
         # Directly exercise __process_initial__ with a two-word part
         result = hn.__process_initial__("Van Berg", firstname=True)
         self.assertEqual(result, "VB")

--- a/tests/test_initials.py
+++ b/tests/test_initials.py
@@ -74,6 +74,10 @@ class InitialsTestCase(HumanNameTestBase):
         self.m(hn.initials(), "J; A; K; D;", hn)
         CONSTANTS.initials_delimiter = _orig
 
+    def test_initials_separator_default_on_constants(self) -> None:
+        from nameparser.config import CONSTANTS
+        self.assertEqual(CONSTANTS.initials_separator, " ")
+
     def test_initials_list(self) -> None:
         hn = HumanName("Andrew Boris Petersen")
         self.m(hn.initials_list(), ["A", "B", "P"], hn)
@@ -89,6 +93,30 @@ class InitialsTestCase(HumanNameTestBase):
     def test_initials_with_prefix(self) -> None:
         hn = HumanName("Alex van Johnson")
         self.m(hn.initials_list(), ["A", "J"], hn)
+
+    def test_initials_delimiter_empty_string_kwarg(self) -> None:
+        # Regression: initials_delimiter='' was silently ignored due to `or` defaulting
+        hn = HumanName("Doe, John A.", initials_delimiter="")
+        self.m(hn.initials(), "J A D", hn)
+
+    def test_initials_format_empty_string_kwarg(self) -> None:
+        # Regression: initials_format='' was silently ignored due to `or` defaulting
+        hn = HumanName("Doe, John A.")
+        hn2 = HumanName("Doe, John A.", initials_format="")
+        assert hn.initials() != hn2.initials()
+        # When format is empty string, result should be either "" or empty_attribute_default
+        result = hn2.initials()
+        assert result == "" or result == hn2.C.empty_attribute_default
+
+    def test_initials_separator_kwarg(self) -> None:
+        # initials_separator="" with initials_format="{first}{middle}{last}" gives
+        # period-separated initials with no spaces — a common academic citation style
+        hn = HumanName(
+            "Doe, John A. Kenneth",
+            initials_separator="",
+            initials_format="{first}{middle}{last}",
+        )
+        self.m(hn.initials(), "J.A.K.D.", hn)
 
     def test_constructor_first(self) -> None:
         hn = HumanName(first="TheName")
@@ -126,3 +154,38 @@ class InitialsTestCase(HumanNameTestBase):
         self.m(hn.first, "TheName", hn)
         self.m(hn.last, "lastname", hn)
         self.m(hn.title, "mytitle", hn)
+
+    def test_initials_separator_multiword_name_part(self) -> None:
+        # __process_initial__ splits on spaces internally for multi-word tokens;
+        # initials_separator must flow through there too.
+        hn = HumanName("", constants=None)
+        hn.C.initials_separator = ""
+        # Directly exercise __process_initial__ with a two-word part
+        result = hn.__process_initial__("Van Berg", firstname=True)
+        self.assertEqual(result, "VB")
+
+    def test_initials_separator_empty_multi_part_middle(self) -> None:
+        # Full workflow from issue #152: empty delimiter + separator + compact format
+        # gives fully concatenated initials with no spaces or punctuation.
+        # Spaces between groups come from initials_format, so that must also be set.
+        hn = HumanName(
+            "Doe, John A. Kenneth",
+            initials_delimiter="",
+            initials_separator="",
+            initials_format="{first}{middle}{last}",
+        )
+        self.m(hn.initials(), "JAKD", hn)
+
+    def test_initials_separator_constants_multi_part_middle(self) -> None:
+        from nameparser.config import CONSTANTS
+        _orig_d = CONSTANTS.initials_delimiter
+        _orig_s = CONSTANTS.initials_separator
+        _orig_f = CONSTANTS.initials_format
+        CONSTANTS.initials_delimiter = ""
+        CONSTANTS.initials_separator = ""
+        CONSTANTS.initials_format = "{first}{middle}{last}"
+        hn = HumanName("Doe, John A. Kenneth")
+        self.m(hn.initials(), "JAKD", hn)
+        CONSTANTS.initials_delimiter = _orig_d
+        CONSTANTS.initials_separator = _orig_s
+        CONSTANTS.initials_format = _orig_f


### PR DESCRIPTION
## Summary

Closes #152.

- **Add `initials_separator`** to `Constants` (default `" "`) and as a `HumanName` kwarg. Controls the joiner *between* consecutive initials within a name group (e.g. two middle names), distinct from `initials_delimiter` which is the trailing character *after* each initial.
- **Fix silent kwarg ignoring** for `string_format`, `initials_format`, and `initials_delimiter`: these used `or`-defaulting which silently discarded falsy values like `""`. Now use `is not None`.
- **Use `initials_separator`** in `__process_initial__` and `initials()` in place of a hardcoded `" "`.
- **Document** the new setting in `docs/usage.rst` with examples showing how all three settings compose.

## Behavior changes

| Before | After |
|---|---|
| `HumanName(..., initials_delimiter='')` silently used `"."` | `initials_delimiter` is `""` as passed |
| `HumanName(..., initials_format='')` silently used default format | `initials_format` is `""` as passed |
| No way to remove spaces between initials within a group | `initials_separator=""` removes them |
| `initials_format="{first}{middle}{last}", initials_delimiter="."` → `"J.A. K.D."` | + `initials_separator=""` → `"J.A.K.D."` |

## Test plan

- [x] `uv run pytest tests/test_initials.py -v` — all initials tests pass
- [x] `uv run pytest` — full suite passes (728 passed, 20 xfailed)
- [x] Verify `HumanName("Doe, John A. Kenneth", initials_separator="", initials_format="{first}{middle}{last}").initials()` returns `"J.A.K.D."`
- [x] Verify `HumanName("Doe, John A. Kenneth", initials_delimiter="", initials_separator="", initials_format="{first}{middle}{last}").initials()` returns `"JAKD"`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)