### PR TITLE
fix: honor single-char symbol conjunctions regardless of name length

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -870,7 +870,7 @@ class HumanName:
         conj_index = [i for i, piece in enumerate(pieces) if self.is_conjunction(piece)]
 
         for i in conj_index:
-            if len(pieces[i]) == 1 and total_length < 4:
+            if len(pieces[i]) == 1 and total_length < 4 and pieces[i].isalpha():
                 # if there are only 3 total parts (minus known titles, suffixes
                 # and prefixes) and this conjunction is a single letter, prefer
                 # treating it as an initial rather than a conjunction.

--- a/tests/test_conjunctions.py
+++ b/tests/test_conjunctions.py
@@ -111,6 +111,14 @@ class HumanNameConjunctionTestCase(HumanNameTestBase):
         self.m(hn.first, "John and Jane", hn)
         self.m(hn.last, "Smith", hn)
 
+    def test_couple_titles_ampersand_conjunction(self) -> None:
+        # issue 151: single-char conjunctions in the conjunctions list should
+        # be honored even when total_length < 4
+        hn = HumanName('Mr. & Mrs. John Smith')
+        self.m(hn.title, "Mr. & Mrs.", hn)
+        self.m(hn.first, "John", hn)
+        self.m(hn.last, "Smith", hn)
+
     def test_title_with_three_part_name_last_initial_is_suffix_uppercase_no_period(self) -> None:
         hn = HumanName("King John Alexander V")
         self.m(hn.title, "King", hn)

--- a/tests/test_conjunctions.py
+++ b/tests/test_conjunctions.py
@@ -119,6 +119,20 @@ class HumanNameConjunctionTestCase(HumanNameTestBase):
         self.m(hn.first, "John", hn)
         self.m(hn.last, "Smith", hn)
 
+    def test_ampersand_conjunction_short_name_no_titles(self) -> None:
+        # & is non-alpha so it should always be honored as a conjunction,
+        # even when total_length < 4 (no titles to inflate the count)
+        hn = HumanName('John & Jane')
+        self.m(hn.first, "John & Jane", hn)
+
+    def test_single_char_alpha_conjunction_still_treated_as_initial_when_short(self) -> None:
+        # single-char alpha conjunctions (e, y) are still treated as initials
+        # when total_length < 4; only non-alpha symbols like & bypass this guard
+        hn = HumanName('John y Jane')
+        self.m(hn.first, "John", hn)
+        self.m(hn.middle, "y", hn)
+        self.m(hn.last, "Jane", hn)
+
     def test_title_with_three_part_name_last_initial_is_suffix_uppercase_no_period(self) -> None:
         hn = HumanName("King John Alexander V")
         self.m(hn.title, "King", hn)


### PR DESCRIPTION
## Summary

- Fixes #151: `"Mr. & Mrs. John Smith"` now correctly parses title as `"Mr. & Mrs."` instead of treating `&` as a first name
- The existing heuristic skipped single-character conjunctions when `total_length < 4` to avoid mistaking alphabetic initials (e.g. `e`, `y`) for conjunctions — but this also incorrectly skipped non-alphabetic symbols like `&`, which can never be initials
- Fix: add `and pieces[i].isalpha()` to the guard, so only alphabetic single-char conjunctions fall back to "treat as initial" behavior; symbols are always honored as conjunctions

## Test plan

- [x] Added `test_couple_titles_ampersand_conjunction` — verified it fails before the fix and passes after
- [x] All 756 existing tests pass (20 xfailed unchanged)
- [x] Existing `test_lowercase_first_initial_conflict_with_conjunction` and related tests still pass — confirming the `e`/`y` initial-vs-conjunction ambiguity is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)