### PR TITLE
fix: recognize single-letter roman numeral suffixes in suffix-comma format (closes #136)

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -487,6 +487,21 @@ class HumanName:
                 return False
         return True
 
+    def are_suffixes_after_comma(self, pieces: Iterable[str]) -> bool:
+        """Like are_suffixes but suffix_not_acronyms members are always
+        recognized, even when they look like single-letter initials.
+
+        Used when detecting suffix-comma format (e.g. "John Ingram, V") where
+        the post-comma position is unambiguous: a single uppercase roman
+        numeral like 'V' is definitionally a suffix there, not an initial.
+        """
+        for piece in pieces:
+            if lc(piece) in self.C.suffix_not_acronyms:
+                continue
+            if not self.is_suffix(piece):
+                return False
+        return True
+
     def is_rootname(self, piece: str) -> bool:
         """
         Is not a known title, suffix or prefix. Just first, middle, last names.
@@ -686,7 +701,7 @@ class HumanName:
 
             post_comma_pieces = self.parse_pieces(parts[1].split(' '), 1)
 
-            if self.are_suffixes(parts[1].split(' ')) \
+            if self.are_suffixes_after_comma(parts[1].split(' ')) \
                     and len(parts[0].split(' ')) > 1:
 
                 # suffix comma:

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -488,12 +488,14 @@ class HumanName:
         return True
 
     def are_suffixes_after_comma(self, pieces: Iterable[str]) -> bool:
-        """Like are_suffixes but suffix_not_acronyms members are always
-        recognized, even when they look like single-letter initials.
+        """Like are_suffixes, but pieces found in suffix_not_acronyms are
+        accepted unconditionally without passing through is_suffix().
 
         Used when detecting suffix-comma format (e.g. "John Ingram, V") where
-        the post-comma position is unambiguous: a single uppercase roman
-        numeral like 'V' is definitionally a suffix there, not an initial.
+        the post-comma position is unambiguous. This covers all
+        suffix_not_acronyms members (i, ii, iii, iv, v, jr, sr, etc.),
+        case-insensitively, including single-letter entries that is_suffix()
+        would otherwise reject via is_an_initial().
         """
         for piece in pieces:
             if lc(piece) in self.C.suffix_not_acronyms:

--- a/tests/test_suffixes.py
+++ b/tests/test_suffixes.py
@@ -35,13 +35,33 @@ class SuffixesTestCase(HumanNameTestBase):
         self.m(hn.suffix, "Jr., MD", hn)
 
     def test_roman_numeral_v_suffix_comma_format(self) -> None:
-        # 'V' is a single uppercase letter, so it was incorrectly matched as an
-        # initial and not recognized as a suffix (issue #136)
+        # suffix-comma position is unambiguous: 'V' must be a suffix, not a single-letter initial
         hn = HumanName("John W. Ingram, V")
         self.m(hn.first, "John", hn)
         self.m(hn.middle, "W.", hn)
         self.m(hn.last, "Ingram", hn)
         self.m(hn.suffix, "V", hn)
+
+    def test_roman_numeral_i_suffix_comma_format(self) -> None:
+        # 'I' has the same single-letter ambiguity as 'V'
+        hn = HumanName("John W. Smith, I")
+        self.m(hn.first, "John", hn)
+        self.m(hn.middle, "W.", hn)
+        self.m(hn.last, "Smith", hn)
+        self.m(hn.suffix, "I", hn)
+
+    def test_suffix_not_acronym_then_acronym_suffix_comma_format(self) -> None:
+        # single-letter suffix_not_acronyms entry followed by an acronym suffix
+        hn = HumanName("John Smith, V MD")
+        self.m(hn.first, "John", hn)
+        self.m(hn.last, "Smith", hn)
+        self.m(hn.suffix, "V MD", hn)
+
+    def test_two_suffix_not_acronyms_suffix_comma_format(self) -> None:
+        hn = HumanName("John Smith, V Jr.")
+        self.m(hn.first, "John", hn)
+        self.m(hn.last, "Smith", hn)
+        self.m(hn.suffix, "V Jr.", hn)
 
     def test_two_suffixes_suffix_comma_format(self) -> None:
         hn = HumanName("Franklin Washington, Jr. MD")

--- a/tests/test_suffixes.py
+++ b/tests/test_suffixes.py
@@ -34,6 +34,15 @@ class SuffixesTestCase(HumanNameTestBase):
         # NOTE: this adds a comma when the original format did not have one.
         self.m(hn.suffix, "Jr., MD", hn)
 
+    def test_roman_numeral_v_suffix_comma_format(self) -> None:
+        # 'V' is a single uppercase letter, so it was incorrectly matched as an
+        # initial and not recognized as a suffix (issue #136)
+        hn = HumanName("John W. Ingram, V")
+        self.m(hn.first, "John", hn)
+        self.m(hn.middle, "W.", hn)
+        self.m(hn.last, "Ingram", hn)
+        self.m(hn.suffix, "V", hn)
+
     def test_two_suffixes_suffix_comma_format(self) -> None:
         hn = HumanName("Franklin Washington, Jr. MD")
         self.m(hn.first, "Franklin", hn)


### PR DESCRIPTION
## Summary

- `HumanName("John W. Ingram, V")` was incorrectly parsing `V` as first name and `John W. Ingram` as last name
- Root cause: `is_suffix()` guards against single uppercase letters via `is_an_initial()`, but roman numeral `V` is exactly a single uppercase letter — so it was never recognized as a suffix
- `IV` happened to work because it's two characters; lowercase `v` (no comma) worked because the initial regex only matches uppercase

## Approach

Rather than removing the `is_an_initial` guard from `is_suffix()` globally (which breaks `"Larry V I"` where `V` should remain a middle initial), the fix is narrowly scoped to the suffix-comma detection site.

Added `are_suffixes_after_comma()` which skips the initial check for `suffix_not_acronyms` members. In suffix-comma format (`First Last, V`), the post-comma position is unambiguous — whatever appears there is a suffix by position, not an initial. This method is used only at the one call site that detects suffix-comma format.

## Test plan

- [x] New test: `test_roman_numeral_v_suffix_comma_format` — `"John W. Ingram, V"` parses correctly
- [x] Existing test `test_roman_numeral_initials` (`"Larry V I"` → middle=V, last=I) still passes — no-comma path unaffected
- [x] Existing test for `"Doe, Rev. John V, Jr."` still passes — lastname-comma path unaffected
- [x] Full suite: 760 passed, 4 skipped, 20 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)