### PR TITLE
fix: recognize trailing suffix_not_acronyms in lastname-comma format (closes #144)

### DIFF
--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -504,6 +504,20 @@ class HumanName:
                 return False
         return True
 
+    def is_suffix_at_lastname_comma_end(self, piece: str, nxt: str | None, parts: list[str]) -> bool:
+        """True when a suffix_not_acronyms member is the final token in the
+        post-comma segment of a lastname-comma name with no explicit
+        comma-separated suffix (e.g. 'Maier, Amy Lauren I').
+
+        When parts[2] exists the caller already has an explicit suffix, making
+        the trailing single-letter more likely a middle initial
+        (e.g. 'Doe, Rev. John V, Jr.'), so the guard len(parts)==2 excludes
+        that case.
+        """
+        return (nxt is None
+                and len(parts) == 2
+                and lc(piece) in self.C.suffix_not_acronyms)
+
     def is_rootname(self, piece: str) -> bool:
         """
         Is not a known title, suffix or prefix. Just first, middle, last names.
@@ -767,7 +781,7 @@ class HumanName:
                     if not self.first:
                         self.first_list.append(piece)
                         continue
-                    if self.is_suffix(piece):
+                    if self.is_suffix(piece) or self.is_suffix_at_lastname_comma_end(piece, nxt, parts):
                         self.suffix_list.append(piece)
                         continue
                     self.middle_list.append(piece)

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -505,14 +505,21 @@ class HumanName:
         return True
 
     def is_suffix_at_lastname_comma_end(self, piece: str, nxt: str | None, parts: list[str]) -> bool:
-        """True when a suffix_not_acronyms member is the final token in the
-        post-comma segment of a lastname-comma name with no explicit
-        comma-separated suffix (e.g. 'Maier, Amy Lauren I').
+        """True when ``piece`` is a suffix_not_acronyms member that should be
+        treated as a suffix at the end of ``parts[1]`` (the post-comma segment)
+        in a lastname-comma name, where ``parts`` is the full comma-split of the
+        name string.
 
-        When parts[2] exists the caller already has an explicit suffix, making
-        the trailing single-letter more likely a middle initial
-        (e.g. 'Doe, Rev. John V, Jr.'), so the guard len(parts)==2 excludes
-        that case.
+        Returns True only when all three conditions hold:
+        - ``nxt is None``: piece is the last token in the post-comma segment
+        - ``len(parts) == 2``: no ``parts[2]`` suffix segment exists
+        - ``lc(piece) in suffix_not_acronyms``
+
+        When ``parts[2]`` exists the caller already declared an explicit suffix
+        via comma (e.g. 'Doe, Rev. John V, Jr.'), making the trailing token more
+        likely a middle initial; ``len(parts) == 2`` excludes that case.
+        Used as an OR alternative to ``is_suffix()`` for pieces that
+        ``is_suffix()`` would reject via ``is_an_initial()``.
         """
         return (nxt is None
                 and len(parts) == 2

--- a/tests/test_suffixes.py
+++ b/tests/test_suffixes.py
@@ -167,12 +167,46 @@ class SuffixesTestCase(HumanNameTestBase):
         self.m(hn.suffix, "Msc.Ed.", hn)
 
     def test_roman_numeral_i_lastname_comma_format(self) -> None:
-        # trailing 'I' in lastname-comma format must be a suffix, not a middle initial (issue #144)
+        # 'I' is in suffix_not_acronyms; trailing suffix_not_acronyms members in
+        # "Lastname, First Middle Suffix" format (no comma-suffix segment) must
+        # parse as suffix, not middle initial (issue #144)
         hn = HumanName("Maier, Amy Lauren I")
         self.m(hn.first, "Amy", hn)
         self.m(hn.middle, "Lauren", hn)
         self.m(hn.last, "Maier", hn)
         self.m(hn.suffix, "I", hn)
+
+    def test_roman_numeral_v_lastname_comma_format(self) -> None:
+        # 'V' shares the same suffix_not_acronyms ambiguity as 'I' (issue #144)
+        hn = HumanName("Smith, John V")
+        self.m(hn.first, "John", hn)
+        self.m(hn.middle, "", hn)
+        self.m(hn.last, "Smith", hn)
+        self.m(hn.suffix, "V", hn)
+
+    def test_roman_numeral_i_no_middle_lastname_comma_format(self) -> None:
+        # no middle name: trailing 'I' must still be a suffix (issue #144)
+        hn = HumanName("Smith, John I")
+        self.m(hn.first, "John", hn)
+        self.m(hn.middle, "", hn)
+        self.m(hn.last, "Smith", hn)
+        self.m(hn.suffix, "I", hn)
+
+    def test_roman_numeral_i_after_single_initial_lastname_comma_format(self) -> None:
+        # single-letter middle initial followed by trailing 'I' (reporter pattern, issue #144)
+        hn = HumanName("Chang, Andy C I")
+        self.m(hn.first, "Andy", hn)
+        self.m(hn.middle, "C", hn)
+        self.m(hn.last, "Chang", hn)
+        self.m(hn.suffix, "I", hn)
+
+    @pytest.mark.xfail
+    def test_roman_numeral_i_with_explicit_suffix_comma_known_limitation(self) -> None:
+        # When an explicit suffix comma is present (len(parts)==3), the trailing 'I'
+        # is conservatively left in middle to avoid misclassifying true initials.
+        # This is a known limitation of is_suffix_at_lastname_comma_end (issue #144).
+        hn = HumanName("Maier, Amy I, Jr.")
+        self.m(hn.suffix, "I, Jr.", hn)
 
     def test_suffix_delimiter_default_on_constants(self) -> None:
         from nameparser.config import CONSTANTS

--- a/tests/test_suffixes.py
+++ b/tests/test_suffixes.py
@@ -166,6 +166,14 @@ class SuffixesTestCase(HumanNameTestBase):
         self.m(hn.last, "Doe", hn)
         self.m(hn.suffix, "Msc.Ed.", hn)
 
+    def test_roman_numeral_i_lastname_comma_format(self) -> None:
+        # trailing 'I' in lastname-comma format must be a suffix, not a middle initial (issue #144)
+        hn = HumanName("Maier, Amy Lauren I")
+        self.m(hn.first, "Amy", hn)
+        self.m(hn.middle, "Lauren", hn)
+        self.m(hn.last, "Maier", hn)
+        self.m(hn.suffix, "I", hn)
+
     def test_suffix_delimiter_default_on_constants(self) -> None:
         from nameparser.config import CONSTANTS
         self.assertIs(CONSTANTS.suffix_delimiter, None)


### PR DESCRIPTION
## Summary

- `HumanName("Maier, Amy Lauren I")` was putting `I` in middle instead of suffix — same root cause as #136 but in a different code path
- In lastname-comma format (`Last, First Middle Suffix`), the post-comma parsing loop calls `is_suffix()` for each token after the first name; `is_suffix()` rejects single uppercase letters via `is_an_initial()`, so `I` fell through to middle

## Approach

Added `is_suffix_at_lastname_comma_end()` which recognizes a trailing `suffix_not_acronyms` member as a suffix when:
1. It is the **last token** in the post-comma segment (`nxt is None`)
2. There is **no explicit comma-separated suffix** in `parts[2]` (`len(parts) == 2`)

The `len(parts) == 2` guard is the key: when a name like `"Doe, Rev. John V, Jr."` has `parts[2] = "Jr."`, the caller already declared a suffix via comma, making the trailing `V` more likely a middle initial. That existing test still passes.

## Known limitation

`"Maier, Amy I, Jr."` — the presence of `Jr.` in `parts[2]` suppresses the fix and leaves `I` in middle. Fixing that edge case cleanly would require additional heuristics; this PR handles the common case from the issue report.

## Test plan

- [x] New test: `test_roman_numeral_i_lastname_comma_format` — `"Maier, Amy Lauren I"` parses correctly
- [x] All four examples from issue #144 verified manually
- [x] `"Doe, Rev. John V, Jr."` existing test still passes (key regression case)
- [x] Full suite: 768 passed, 4 skipped, 20 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)