### PR TITLE
docs: add CITATION.cff (#118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ uv run sphinx-build -b html docs dist/docs
 # 0. Review docs/ for anything stale — especially usage.rst (examples, API surface)
 #    and any .rst files that reference config constants or HumanName kwargs
 #    Also review AGENTS.md for stale commands, architecture notes, or gotchas
-# 1. Bump VERSION in nameparser/_version.py
+# 1. Bump VERSION in nameparser/_version.py (and the `version:` field in CITATION.cff to match)
 # 2. Stamp "Unreleased" → "X.Y.Z - Month DD, YYYY" in docs/release_log.rst
 # 3. git commit + git tag -a vX.Y.Z -m "Release X.Y.Z"
 # 4. git push origin master && git push origin vX.Y.Z  ← tag must be pushed separately before gh release create

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: python-nameparser
+abstract: "A simple Python module for parsing human names into their individual components."
+type: software
+authors:
+  - family-names: Gulbranson
+    given-names: Derek
+repository-code: "https://github.com/derek73/python-nameparser"
+url: "https://github.com/derek73/python-nameparser"
+license: LGPL-2.1-or-later
+version: "1.2.1"


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a **"Cite this repository"** button and downstream users get a consistent citation format. Resolves the request in #118.

Human-readable form:
> Gulbranson, D. *python-nameparser* (Version X.Y). GitHub. https://github.com/derek73/python-nameparser

Also adds a one-line reminder to the release checklist to bump the `version:` field in `CITATION.cff` alongside `nameparser/_version.py` (currently `1.2.1`) so it doesn't go stale.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)