### PR TITLE
Remove unneeded re.U/re.UNICODE flags

### DIFF
--- a/nameparser/config/regexes.py
+++ b/nameparser/config/regexes.py
@@ -4,34 +4,32 @@ import re
 re_emoji = re.compile('['  # lgtm[py/overly-large-range]
     '\U0001F300-\U0001F64F'
     '\U0001F680-\U0001F6FF'
-    '\u2600-\u26FF\u2700-\u27BF]+',
-    re.UNICODE)
+    '\u2600-\u26FF\u2700-\u27BF]+')
 
 EMPTY_REGEX = re.compile('')
 
 REGEXES = set([
-    ("spaces", re.compile(r"\s+", re.U)),
-    ("word", re.compile(r"(\w|\.)+", re.U)),
-    ("mac", re.compile(r'^(ma?c)(\w{2,})', re.I | re.U)),
-    ("initial", re.compile(r'^(\w\.|[A-Z])?$', re.U)),
-    ("quoted_word", re.compile(r'(?<!\w)\'([^\s]*?)\'(?!\w)', re.U)),
-    ("double_quotes", re.compile(r'\"(.*?)\"', re.U)),
-    ("parenthesis", re.compile(r'\((.*?)\)', re.U)),
-    ("roman_numeral", re.compile(r'^(X|IX|IV|V?I{0,3})$', re.I | re.U)),
-    ("no_vowels",re.compile(r'^[^aeyiuo]+$', re.I | re.U)),
-    ("period_not_at_end",re.compile(r'.*\..+$', re.I | re.U)),
+    ("spaces", re.compile(r"\s+")),
+    ("word", re.compile(r"(\w|\.)+")),
+    ("mac", re.compile(r'^(ma?c)(\w{2,})', re.I)),
+    ("initial", re.compile(r'^(\w\.|[A-Z])?$')),
+    ("quoted_word", re.compile(r'(?<!\w)\'([^\s]*?)\'(?!\w)')),
+    ("double_quotes", re.compile(r'\"(.*?)\"')),
+    ("parenthesis", re.compile(r'\((.*?)\)')),
+    ("roman_numeral", re.compile(r'^(X|IX|IV|V?I{0,3})$', re.I)),
+    ("no_vowels",re.compile(r'^[^aeyiuo]+$', re.I)),
+    ("period_not_at_end",re.compile(r'.*\..+$', re.I)),
     ("emoji",re_emoji),
-    ("phd", re.compile(r'\s(ph\.?\s+d\.?)', re.I | re.U)),
-    ("space_before_comma", re.compile(r'\s+,', re.U)),
+    ("phd", re.compile(r'\s(ph\.?\s+d\.?)', re.I)),
+    ("space_before_comma", re.compile(r'\s+,')),
     ("patronymic", re.compile(
         r'(ovich|ovna|evich|evna|ichna|ilyich|kuzmich|lukich|fomich|fokich)$',
-        re.I | re.U,
+        re.I,
     )),
     ("patronymic_cyrillic", re.compile(
         r'(ович|овна|евич|евна|ична|ильич|кузьмич|лукич|фомич|фокич)$',
-        re.U,
     )),
-    ("period_abbreviation", re.compile(r'^[^\W\d_]{2,}\.$', re.U)),
+    ("period_abbreviation", re.compile(r'^[^\W\d_]{2,}\.$')),
 ])
 """
 All regular expressions used by the parser are precompiled and stored in the config.

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -64,7 +64,7 @@ class ConstantsCustomizationTests(HumanNameTestBase):
     def test_can_add_global_extra_nickname_delimiter(self) -> None:
         # https://github.com/derek73/python-nameparser/issues/112
         hn = HumanName("")
-        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}', re.U)
+        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}')
         hn2 = HumanName("Benjamin {Ben} Franklin")
         self.assertEqual(hn2.has_own_config, False)
         self.m(hn2.nickname, "Ben", hn2)
@@ -141,7 +141,7 @@ class ConstantsCustomizationTests(HumanNameTestBase):
         c.titles.add('customtitle')
         c.prefixes.add('customprefix')
         c.titles.remove('hon')
-        c.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}', re.U)
+        c.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}')
 
         # Safe: round-tripping a Constants the test just built, not untrusted data.
         restored = pickle.loads(pickle.dumps(c))
@@ -209,7 +209,7 @@ class ConstantsCustomizationTests(HumanNameTestBase):
         rather than only incidentally via conftest's autouse snapshot/restore.
         """
         c = Constants()
-        c.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}', re.U)
+        c.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}')
 
         dup = copy.deepcopy(c.extra_nickname_delimiters)
 

--- a/tests/test_nicknames.py
+++ b/tests/test_nicknames.py
@@ -21,7 +21,7 @@ class NicknameTestCase(HumanNameTestBase):
         hn = HumanName("Benjamin {Ben} Franklin", constants=None)
         # curly braces aren't a recognized delimiter by default
         self.m(hn.nickname, "", hn)
-        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}', re.U)
+        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}')
         hn.parse_full_name()
         self.m(hn.first, "Benjamin", hn)
         self.m(hn.last, "Franklin", hn)
@@ -29,7 +29,7 @@ class NicknameTestCase(HumanNameTestBase):
 
     def test_remove_custom_nickname_delimiter(self) -> None:
         hn = HumanName("Benjamin {Ben} Franklin", constants=None)
-        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}', re.U)
+        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}')
         hn.parse_full_name()
         self.m(hn.nickname, "Ben", hn)
         del hn.C.extra_nickname_delimiters['curly_braces']
@@ -40,8 +40,8 @@ class NicknameTestCase(HumanNameTestBase):
         # Two extras registered at once must both be recognized in a single
         # parse, independent of insertion order.
         hn = HumanName("Benjamin {Ben} <Benny> Franklin", constants=None)
-        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}', re.U)
-        hn.C.extra_nickname_delimiters['angle_brackets'] = re.compile(r'<(.*?)>', re.U)
+        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}')
+        hn.C.extra_nickname_delimiters['angle_brackets'] = re.compile(r'<(.*?)>')
         hn.parse_full_name()
         self.m(hn.first, "Benjamin", hn)
         self.m(hn.last, "Franklin", hn)
@@ -53,7 +53,7 @@ class NicknameTestCase(HumanNameTestBase):
         # parse_nicknames() also consults extra_nickname_delimiters.
         hn = HumanName("Benjamin [Ben] Franklin", constants=None)
         self.m(hn.nickname, "", hn)
-        hn.C.regexes['parenthesis'] = re.compile(r'\[(.*?)\]', re.U)
+        hn.C.regexes['parenthesis'] = re.compile(r'\[(.*?)\]')
         hn.parse_full_name()
         self.m(hn.first, "Benjamin", hn)
         self.m(hn.last, "Franklin", hn)
@@ -193,7 +193,7 @@ class NicknameTestCase(HumanNameTestBase):
         # handle_match() is applied uniformly regardless of which delimiter
         # matched, not just the three built-ins.
         hn = HumanName("JEFFREY {JD} BRICKEN", constants=None)
-        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}', re.U)
+        hn.C.extra_nickname_delimiters['curly_braces'] = re.compile(r'\{(.*?)\}')
         hn.parse_full_name()
         self.m(hn.nickname, "JD", hn)
         self.m(hn.suffix, "", hn)

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -298,7 +298,7 @@ class HumanNamePythonTests(HumanNameTestBase):
         self.assertIs(hn.C, C)
 
     def test_override_regex(self) -> None:
-        var = TupleManager([("spaces", re.compile(r"\s+", re.U)),])
+        var = TupleManager([("spaces", re.compile(r"\s+")),])
         C = Constants(regexes=var)
         hn = HumanName(constants=C)
         self.assertTrue(hn.C.regexes == var)
@@ -340,7 +340,7 @@ class HumanNamePythonTests(HumanNameTestBase):
         self.assertTrue(sorted(hn.C.conjunctions) == sorted(var))
 
     def test_override_capitalization_exceptions(self) -> None:
-        var = TupleManager([("spaces", re.compile(r"\s+", re.U)),])
+        var = TupleManager([("spaces", re.compile(r"\s+")),])
         C = Constants(capitalization_exceptions=var)
         hn = HumanName(constants=C)
         self.assertTrue(hn.C.capitalization_exceptions == var)


### PR DESCRIPTION
## Summary
- `re.U`/`re.UNICODE` is a no-op in Python 3 since `str` patterns are already Unicode-aware by default (it only matters for `bytes` patterns, which this project doesn't use). It was a leftover from the Python 2 era.
- Removed all `re.U`/`re.UNICODE` occurrences from `nameparser/config/regexes.py` and the test files that mirror those patterns (`tests/test_python_api.py`, `tests/test_nicknames.py`, `tests/test_constants.py`).
- No behavior change intended.

## Test plan
- [x] `python3 -m pytest -q` — 1074 passed, 4 skipped, 22 xfailed (same as before the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)