### PR TITLE
Modernize string formatting to f-strings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Nameparser'
-copyright = '{:%Y}, Derek Gulbranson'.format(date.today())
+copyright = f'{date.today():%Y}, Derek Gulbranson'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -75,7 +75,7 @@ class SetManager(Set):
         return self.elements
 
     def __repr__(self) -> str:
-        return "SetManager({})".format(self.elements)  # used for docs
+        return f"SetManager({self.elements})"  # used for docs
 
     def __iter__(self) -> Iterator[str]:
         return iter(self.elements)

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -194,7 +194,7 @@ class HumanName:
     def __str__(self) -> str:
         if self.string_format is not None:
             # string_format = "{title} {first} {middle} {last} {suffix} ({nickname})"
-            _s = self.string_format.format(**self.as_dict())
+            _s = self.string_format.format(**self.as_dict())  # noqa: UP032
             # remove trailing punctuation from missing nicknames
             _s = _s.replace(str(self.C.empty_attribute_default), '').replace(" ()", "").replace(" ''", "").replace(' ""', "")
             _s = self.C.regexes.space_before_comma.sub(',', _s)
@@ -206,18 +206,18 @@ class HumanName:
 
     def __repr__(self) -> str:
         if self.unparsable:
-            _string = "<%(class)s : [ Unparsable ] >" % {'class': self.__class__.__name__, }
+            _string = f"<{self.__class__.__name__} : [ Unparsable ] >"
         else:
-            _string = "<%(class)s : [\n\ttitle: %(title)r \n\tfirst: %(first)r \n\tmiddle: %(middle)r \n\tlast: %(last)r \n\tsuffix: %(suffix)r\n\tnickname: %(nickname)r\n\tmaiden: %(maiden)r\n]>" % {
-                'class': self.__class__.__name__,
-                'title': self.title or '',
-                'first': self.first or '',
-                'middle': self.middle or '',
-                'last': self.last or '',
-                'suffix': self.suffix or '',
-                'nickname': self.nickname or '',
-                'maiden': self.maiden or '',
-            }
+            attrs = (
+                f"\ttitle: {self.title or ''!r} \n"
+                f"\tfirst: {self.first or ''!r} \n"
+                f"\tmiddle: {self.middle or ''!r} \n"
+                f"\tlast: {self.last or ''!r} \n"
+                f"\tsuffix: {self.suffix or ''!r}\n"
+                f"\tnickname: {self.nickname or ''!r}\n"
+                f"\tmaiden: {self.maiden or ''!r}"
+            )
+            _string = f"<{self.__class__.__name__} : [\n{attrs}\n]>"
         return _string
 
     def as_dict(self, include_empty: bool = True) -> dict[str, str]:
@@ -320,7 +320,7 @@ class HumanName:
             if len(last_initials_list) else ""
         }
 
-        _s = self.initials_format.format(**initials_dict)
+        _s = self.initials_format.format(**initials_dict)  # noqa: UP032
         return self.collapse_whitespace(_s) or self.C.empty_attribute_default
 
     @property
@@ -552,7 +552,7 @@ class HumanName:
         else:
             raise TypeError(
                 "Can only assign strings, lists or None to name attributes."
-                " Got {}".format(type(value)))
+                f" Got {type(value)}")
         setattr(self, attr+"_list", self.parse_pieces(val))
 
     # Parse helpers
@@ -1163,7 +1163,7 @@ class HumanName:
         for part in parts:
             if not isinstance(part, (str, bytes)):
                 raise TypeError("Name parts must be strings. "
-                                " Got {}".format(type(part)))
+                                f" Got {type(part)}")
             output += [x.strip(' ,') for x in part.split(' ')]
 
         # If part contains periods, check if it's multiple titles or suffixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,4 @@ extend-select = [
 ]
 ignore = [
   "E74",     # ambiguous-{variable,class,function}-name (I have trouble believing that these are real rules)
-  "UP031",   # printf-string-formatting (the code already uses % formatting)
-  "UP032",   # f-string (the code already uses str.format)
 ]

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,12 +18,7 @@ class HumanNameTestBase(Generic[T]):
         """assertEqual with a better message and awareness of hn.C.empty_attribute_default"""
         expected_ = expected or hn.C.empty_attribute_default
         try:
-            assert actual == expected_, "'%s' != '%s' for '%s'\n%r" % (
-                actual,
-                expected,
-                hn.original,
-                hn,
-            )
+            assert actual == expected_, f"{actual!r} != {expected!r} for {hn.original!r}\n{hn!r}"
         except UnicodeDecodeError:
             assert actual == expected_, f"actual={actual!r} != expected={expected_!r}"
 

--- a/tests/test_variations.py
+++ b/tests/test_variations.py
@@ -2,6 +2,8 @@ from nameparser import HumanName
 
 from tests.base import HumanNameTestBase
 
+from types import SimpleNamespace
+
 
 TEST_NAMES = (
     "John Doe",
@@ -199,18 +201,19 @@ class HumanNameVariationTests(HumanNameTestBase):
         for name in self.TEST_NAMES:
             hn = HumanName(name)
             if len(hn.suffix_list) > 1:
-                hn = HumanName("{title} {first} {middle} {last} {suffix}".format(**hn.as_dict()).split(',')[0])
+                d = SimpleNamespace(**hn.as_dict())
+                hn = HumanName(f"{d.title} {d.first} {d.middle} {d.last} {d.suffix}".split(',')[0])
             hn.C.empty_attribute_default = ''  # format strings below require empty string
-            hn_dict = hn.as_dict()
-            nocomma = HumanName("{title} {first} {middle} {last} {suffix}".format(**hn_dict))
-            lastnamecomma = HumanName("{last}, {title} {first} {middle} {suffix}".format(**hn_dict))
-            if hn.suffix:
-                suffixcomma = HumanName("{title} {first} {middle} {last}, {suffix}".format(**hn_dict))
-            if hn.nickname:
-                nocomma = HumanName("{title} {first} {middle} {last} {suffix} ({nickname})".format(**hn_dict))
-                lastnamecomma = HumanName("{last}, {title} {first} {middle} {suffix} ({nickname})".format(**hn_dict))
-                if hn.suffix:
-                    suffixcomma = HumanName("{title} {first} {middle} {last}, {suffix} ({nickname})".format(**hn_dict))
+            d = SimpleNamespace(**hn.as_dict())
+            nocomma = HumanName(f"{d.title} {d.first} {d.middle} {d.last} {d.suffix}")
+            lastnamecomma = HumanName(f"{d.last}, {d.title} {d.first} {d.middle} {d.suffix}")
+            if d.suffix:
+                suffixcomma = HumanName(f"{d.title} {d.first} {d.middle} {d.last}, {d.suffix}")
+            if d.nickname:
+                nocomma = HumanName(f"{d.title} {d.first} {d.middle} {d.last} {d.suffix} ({d.nickname})")
+                lastnamecomma = HumanName(f"{d.last}, {d.title} {d.first} {d.middle} {d.suffix} ({d.nickname})")
+                if d.suffix:
+                    suffixcomma = HumanName(f"{d.title} {d.first} {d.middle} {d.last}, {d.suffix} ({d.nickname})")
             for attr in hn._members:
                 self.m(getattr(hn, attr), getattr(nocomma, attr), hn)
                 self.m(getattr(hn, attr), getattr(lastnamecomma, attr), hn)


### PR DESCRIPTION
## Summary

Modernized all string formatting across the codebase from Python 2-era styles (% formatting, `.format()`) to Python 3.10+ f-strings.

## Changes

- **Converted all `.format()` and `%` formatting to f-strings** across main code, tests, and docs
- **Updated ruff config** to remove UP031/UP032 ignores (legacy Python 2 compatibility)
- **Added noqa comments** to dynamic template `.format()` calls that can't be converted (e.g., `string_format.format(**dict)`)
- **Improved test readability** by using `SimpleNamespace` for dot notation access in `test_variations.py`
- **Refactored `__repr__` method** in parser.py for better readability—broke long f-string into multi-line `attrs` construction

## Files Changed

- `nameparser/parser.py`: Converted .format() and % formatting to f-strings, refactored __repr__
- `nameparser/config/__init__.py`: Converted .format() to f-string in SetManager.__repr__
- `tests/test_variations.py`: Converted to f-strings with SimpleNamespace for dot notation
- `tests/base.py`: Converted % formatting to f-strings in assertion messages
- `docs/conf.py`: Converted .format() with format spec to f-string
- `pyproject.toml`: Removed UP031 and UP032 from ruff ignore list

## Testing

✅ All 1182 tests pass
✅ All ruff checks pass (including the now-enabled UP031/UP032 rules)