### PR TITLE
Add unit tests for group_contiguous_integers

### DIFF
--- a/tests/test_parser_util.py
+++ b/tests/test_parser_util.py
@@ -1,0 +1,38 @@
+from nameparser.parser import group_contiguous_integers
+
+
+def test_empty_list_returns_no_ranges() -> None:
+    assert group_contiguous_integers([]) == []
+
+
+def test_all_isolated_values_returns_no_ranges() -> None:
+    # no two values are adjacent, so nothing counts as a "run"
+    assert group_contiguous_integers([1, 3, 5]) == []
+
+
+def test_single_value_returns_no_ranges() -> None:
+    # a run of length 1 isn't a contiguous "run" by this function's definition
+    assert group_contiguous_integers([5]) == []
+
+
+def test_pair_of_adjacent_values_is_smallest_valid_run() -> None:
+    assert group_contiguous_integers([4, 5]) == [(4, 5)]
+
+
+def test_single_contiguous_run() -> None:
+    assert group_contiguous_integers([1, 2, 3]) == [(1, 3)]
+
+
+def test_multiple_separate_contiguous_runs() -> None:
+    assert group_contiguous_integers([1, 2, 5, 6, 7, 9]) == [(1, 2), (5, 7)]
+
+
+def test_isolated_values_between_runs_are_excluded() -> None:
+    assert group_contiguous_integers([1, 2, 4, 6, 7]) == [(1, 2), (6, 7)]
+
+
+def test_unsorted_input_is_not_treated_as_contiguous() -> None:
+    # the function assumes ascending, strictly increasing input (as produced
+    # by an `enumerate`-based index scan, which is how join_on_conjunctions
+    # uses it); descending or out-of-order input won't find real-world runs
+    assert group_contiguous_integers([3, 2, 1]) == []

--- a/tests/test_parser_util.py
+++ b/tests/test_parser_util.py
@@ -32,7 +32,8 @@ def test_isolated_values_between_runs_are_excluded() -> None:
 
 
 def test_unsorted_input_is_not_treated_as_contiguous() -> None:
-    # the function assumes ascending, strictly increasing input (as produced
-    # by an `enumerate`-based index scan, which is how join_on_conjunctions
-    # uses it); descending or out-of-order input won't find real-world runs
+    # the grouping key (enumerate index - value) only repeats for ascending,
+    # strictly increasing runs (as produced by an `enumerate`-based index
+    # scan, which is how join_on_conjunctions uses it); a descending
+    # sequence changes the key at every step, so no run is ever found
     assert group_contiguous_integers([3, 2, 1]) == []


### PR DESCRIPTION
## Summary
- `group_contiguous_integers` (nameparser/parser.py) is a pure, module-level utility used by `join_on_conjunctions` to find contiguous runs of conjunction indices, but had no direct test coverage — only indirect coverage through HumanName-level parsing tests.
- Adds `tests/test_parser_util.py` with focused tests for its actual contract: empty input, isolated single values, the smallest valid run (an adjacent pair), a single run, multiple separate runs, isolated values between runs, and a note that it assumes ascending/strictly-increasing input (unsorted input isn't treated as contiguous).

Follow-up from #209, split out per review discussion since this function itself wasn't touched by that PR.

## Test plan
- [x] `python -m pytest tests/test_parser_util.py -v` — 16 passed (8 tests × default/none config parametrization)
- [x] `python -m pytest -q` — 1272 passed, 4 skipped, 22 xfailed (up from 1256 baseline by exactly the 16 new test cases; zero regressions)