### PR TITLE
Restore Constants pickle migration shim, correct its version history

### DIFF
--- a/docs/release_log.rst
+++ b/docs/release_log.rst
@@ -1,12 +1,6 @@
 Release Log
 ===========
 * 1.3.0 - Unreleased
-
-    **Upgrade note — pickle migration**: ``Constants`` pickles written before
-    1.2.1 cannot be loaded under 1.3.0+. If you have persisted blobs, upgrade
-    to 1.2.1 first (which includes a one-version compatibility shim), load and
-    re-pickle under 1.2.1, then upgrade to 1.3.0.
-
     - Add ``non_first_name_prefixes`` to ``Constants``: a leading particle that is never a first name (e.g. ``"de Mesnil"``, ``"dos Santos"``) now parses as a surname with an empty first name, instead of treating the particle as the first name (closes #121)
     - Add a first-class ``maiden`` field and ``maiden_delimiters`` to ``Constants``, so a delimiter (e.g. parenthesis) can be routed to ``maiden`` instead of ``nickname`` for alternate/maiden surnames, e.g. ``"Baker (Johnson), Jenny"`` (closes #22)
     - Fix suffix-shaped parenthesized/quoted content (e.g. ``"(Ret)"``, ``"(MBA)"``) being misclassified as a nickname instead of a suffix (closes #111)

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -535,6 +535,16 @@ class Constants:
         # unpickling.
         self._pst = None
         for name, value in state.items():
+            # Migration shim: pickles written before this fix (1.3.0 and earlier,
+            # including 1.2.1) used a dir() sweep for __getstate__, so their state
+            # carries the read-only ``suffixes_prefixes_titles`` property. Skip any
+            # such computed property rather than raising AttributeError on its
+            # missing setter; the real config is restored from the other keys. We
+            # don't promise to read pre-fix blobs forever — this only smooths
+            # migration for anyone persisting them, and can be dropped a release
+            # or two after 1.3.0 once they've re-pickled.
+            if isinstance(getattr(type(self), name, None), property):
+                continue
             setattr(self, name, value)
         # Verify each descriptor-backed attr was restored. Without this, a missing
         # key surfaces later as AttributeError: 'Constants' object has no attribute

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -166,6 +166,32 @@ class ConstantsCustomizationTests(HumanNameTestBase):
 
         self.assertEqual(restored.empty_attribute_default, None)
 
+    def test_unpickle_legacy_state_with_property_key(self) -> None:
+        """Pickles written by older versions must still load.
+
+        The previous __getstate__ built its state from a dir() sweep, which
+        always included the computed `suffixes_prefixes_titles` property (no
+        customization required). That property has no setter, so __setstate__
+        must skip such keys instead of raising AttributeError.
+
+        Covers the temporary migration shim in __setstate__; remove this test
+        when that shim is dropped (a release or two after 1.3.0).
+        """
+        c = Constants()
+        c.titles.add('legacytitle')
+        # Reproduce the legacy dir()-sweep state dict, which carries the
+        # read-only `suffixes_prefixes_titles` property alongside the real config.
+        legacy_state = {
+            name: getattr(c, name) for name in dir(c) if not name.startswith('_')
+        }
+        self.assertIn('suffixes_prefixes_titles', legacy_state)
+
+        restored = Constants.__new__(Constants)
+        restored.__setstate__(legacy_state)
+
+        # The real customization is recovered and the property key is ignored.
+        self.assertIn('legacytitle', restored.titles)
+
     def test_pickle_roundtrip_preserves_regex_manager_subclass(self) -> None:
         """regexes must round-trip as a RegexTupleManager, not a plain TupleManager.
 


### PR DESCRIPTION
## Summary
- Restore the `Constants.__setstate__` migration shim that skips the legacy `suffixes_prefixes_titles` property key found in pickles written before the `#167` `__getstate__`/`__setstate__` rewrite.
- Correct the shim's comments and the removal commit's mistaken premise: `git diff v1.2.0 v1.2.1 -- nameparser/config/__init__.py` shows no changes, so there was never a "1.2.1 pickle shim" to bridge through — the shim was only ever added and removed within the unreleased 1.3.0 branch.
- Remove the `docs/release_log.rst` upgrade note describing a nonexistent "upgrade to 1.2.1 first" migration path, since the restored shim makes old pickles (any version through 1.2.1) load directly under 1.3.0+.
- Restore `test_unpickle_legacy_state_with_property_key` in `tests/test_constants.py`.

## Test plan
- [x] `python -m pytest tests/test_constants.py -k "pickle or unpickle" -v` — 10 passed
- [x] `python -m pytest tests/ -q` — 1264 passed, 4 skipped, 22 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)