### PR TITLE
Normalize HumanName repr indentation and trailing whitespace

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,13 +69,13 @@ Quick Start Example
     >>> name = HumanName("Dr. Juan Q. Xavier de la Vega III (Doc Vega)")
     >>> name 
     <HumanName : [
-    	title: 'Dr.' 
-    	first: 'Juan' 
-    	middle: 'Q. Xavier' 
-    	last: 'de la Vega' 
-    	suffix: 'III'
-    	nickname: 'Doc Vega'
-    	maiden: ''
+        title: 'Dr.'
+        first: 'Juan'
+        middle: 'Q. Xavier'
+        last: 'de la Vega'
+        suffix: 'III'
+        nickname: 'Doc Vega'
+        maiden: ''
     ]>
     >>> name.last
     'de la Vega'
@@ -99,13 +99,13 @@ and "post-nominal" would probably be better names.)
     >>> name = HumanName("1 & 2, 3 4 5, Mr.")
     >>> name 
     <HumanName : [
-    	title: '' 
-    	first: '3' 
-    	middle: '4 5' 
-    	last: '1 & 2'
-    	suffix: 'Mr.'
-    	nickname: ''
-    	maiden: ''
+        title: ''
+        first: '3'
+        middle: '4 5'
+        last: '1 & 2'
+        suffix: 'Mr.'
+        nickname: ''
+        maiden: ''
     ]>
 
 Customization

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -348,13 +348,13 @@ constant so that "Hon" can be parsed as a first name.
     >>> hn = HumanName("Hon Solo")
     >>> hn
     <HumanName : [
-      title: 'Hon'
-      first: ''
-      middle: ''
-      last: 'Solo'
-      suffix: ''
-      nickname: ''
-      maiden: ''
+        title: 'Hon'
+        first: ''
+        middle: ''
+        last: 'Solo'
+        suffix: ''
+        nickname: ''
+        maiden: ''
     ]>
     >>> from nameparser.config import CONSTANTS
     >>> CONSTANTS.titles.remove('hon')
@@ -362,13 +362,13 @@ constant so that "Hon" can be parsed as a first name.
     >>> hn = HumanName("Hon Solo")
     >>> hn
     <HumanName : [
-      title: ''
-      first: 'Hon'
-      middle: ''
-      last: 'Solo'
-      suffix: ''
-      nickname: ''
-      maiden: ''
+        title: ''
+        first: 'Hon'
+        middle: ''
+        last: 'Solo'
+        suffix: ''
+        nickname: ''
+        maiden: ''
     ]>
 
 
@@ -403,13 +403,13 @@ making them lower case and removing periods.
     >>> hn = HumanName("Assoc Dean of Chemistry Robert Johns", constants=constants)
     >>> hn
     <HumanName : [
-      title: 'Assoc Dean of Chemistry'
-      first: 'Robert'
-      middle: ''
-      last: 'Johns'
-      suffix: ''
-      nickname: ''
-      maiden: ''
+        title: 'Assoc Dean of Chemistry'
+        first: 'Robert'
+        middle: ''
+        last: 'Johns'
+        suffix: ''
+        nickname: ''
+        maiden: ''
     ]>
 
 
@@ -431,13 +431,13 @@ the config on one instance could modify the behavior of another instance.
     >>> other_instance = HumanName("Dean Robert Johns")
     >>> other_instance # Dean parses as title
     <HumanName : [
-      title: 'Dean'
-      first: 'Robert'
-      middle: ''
-      last: 'Johns'
-      suffix: ''
-      nickname: ''
-      maiden: ''
+        title: 'Dean'
+        first: 'Robert'
+        middle: ''
+        last: 'Johns'
+        suffix: ''
+        nickname: ''
+        maiden: ''
     ]>
 
 
@@ -459,13 +459,13 @@ reference to the module-level config values with the behavior described above.
     >>> other_instance = HumanName("Dean Robert Johns", None) # <-- pass None for per-instance config
     >>> other_instance
     <HumanName : [
-      title: ''
-      first: 'Dean'
-      middle: 'Robert'
-      last: 'Johns'
-      suffix: ''
-      nickname: ''
-      maiden: ''
+        title: ''
+        first: 'Dean'
+        middle: 'Robert'
+        last: 'Johns'
+        suffix: ''
+        nickname: ''
+        maiden: ''
     ]>
     >>> other_instance.has_own_config
     True
@@ -531,13 +531,13 @@ directly to the attribute.
   >>> hn.suffix = "Md."
   >>> hn.suffix
   <HumanName : [
-    title: 'Associate Processor'
-    first: 'John'
-    middle: 'A. Kenneth'
-    last: 'Doe'
-    suffix: 'Md.'
-    nickname: ''
-    maiden: ''
+      title: 'Associate Processor'
+      first: 'John'
+      middle: 'A. Kenneth'
+      last: 'Doe'
+      suffix: 'Md.'
+      nickname: ''
+      maiden: ''
   ]>
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,23 +34,23 @@ Requires Python 3.10+.
     >>> name.full_name = "Juan Q. Xavier Velasquez y Garcia, Jr."
     >>> name
     <HumanName : [
-    	title: '' 
-    	first: 'Juan' 
-    	middle: 'Q. Xavier' 
-    	last: 'Velasquez y Garcia' 
-    	suffix: 'Jr.'
-    	nickname: ''
-    	maiden: ''
+        title: ''
+        first: 'Juan'
+        middle: 'Q. Xavier'
+        last: 'Velasquez y Garcia'
+        suffix: 'Jr.'
+        nickname: ''
+        maiden: ''
     ]>
     >>> name.middle = "Jason Alexander"
     >>> name.middle
     'Jason Alexander'
     >>> name
     <HumanName : [
-        title: '' 
-        first: 'Juan' 
-        middle: 'Jason Alexander' 
-        last: 'Velasquez y Garcia' 
+        title: ''
+        first: 'Juan'
+        middle: 'Jason Alexander'
+        last: 'Velasquez y Garcia'
         suffix: 'Jr.'
         nickname: ''
         maiden: ''
@@ -139,13 +139,13 @@ available from the nickname attribute.
     >>> name = HumanName('Jonathan "John" A. Smith')
     >>> name
     <HumanName : [
-      title: ''
-      first: 'Jonathan'
-      middle: 'A.'
-      last: 'Smith'
-      suffix: ''
-      nickname: 'John'
-      maiden: ''
+        title: ''
+        first: 'Jonathan'
+        middle: 'A.'
+        last: 'Smith'
+        suffix: ''
+        nickname: 'John'
+        maiden: ''
     ]>
 
 Exception: content that looks like a suffix (a member of
@@ -161,13 +161,13 @@ written in parenthesis.
     >>> name = HumanName('Andrew Perkins (MBA)')
     >>> name
     <HumanName : [
-      title: ''
-      first: 'Andrew'
-      middle: ''
-      last: 'Perkins'
-      suffix: 'MBA'
-      nickname: ''
-      maiden: ''
+        title: ''
+        first: 'Andrew'
+        middle: ''
+        last: 'Perkins'
+        suffix: 'MBA'
+        nickname: ''
+        maiden: ''
     ]>
 
 A few suffix acronyms, listed in
@@ -182,13 +182,13 @@ reading in that ambiguous context:
     >>> name = HumanName('JEFFREY (JD) BRICKEN')
     >>> name
     <HumanName : [
-      title: ''
-      first: 'JEFFREY'
-      middle: ''
-      last: 'BRICKEN'
-      suffix: ''
-      nickname: 'JD'
-      maiden: ''
+        title: ''
+        first: 'JEFFREY'
+        middle: ''
+        last: 'BRICKEN'
+        suffix: ''
+        nickname: 'JD'
+        maiden: ''
     ]>
 
 Leading Period-Abbreviation Titles
@@ -208,13 +208,13 @@ word appearing after the first name is left as a middle name.
     >>> name = HumanName("Major. Dona Smith")
     >>> name
     <HumanName : [
-      title: 'Major.'
-      first: 'Dona'
-      middle: ''
-      last: 'Smith'
-      suffix: ''
-      nickname: ''
-      maiden: ''
+        title: 'Major.'
+        first: 'Dona'
+        middle: ''
+        last: 'Smith'
+        suffix: ''
+        nickname: ''
+        maiden: ''
     ]>
     >>> name = HumanName("J. Smith")
     >>> name.first

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -209,13 +209,13 @@ class HumanName:
             _string = f"<{self.__class__.__name__} : [ Unparsable ] >"
         else:
             attrs = (
-                f"\ttitle: {self.title or ''!r} \n"
-                f"\tfirst: {self.first or ''!r} \n"
-                f"\tmiddle: {self.middle or ''!r} \n"
-                f"\tlast: {self.last or ''!r} \n"
-                f"\tsuffix: {self.suffix or ''!r}\n"
-                f"\tnickname: {self.nickname or ''!r}\n"
-                f"\tmaiden: {self.maiden or ''!r}"
+                f"    title: {self.title or ''!r}\n"
+                f"    first: {self.first or ''!r}\n"
+                f"    middle: {self.middle or ''!r}\n"
+                f"    last: {self.last or ''!r}\n"
+                f"    suffix: {self.suffix or ''!r}\n"
+                f"    nickname: {self.nickname or ''!r}\n"
+                f"    maiden: {self.maiden or ''!r}"
             )
             _string = f"<{self.__class__.__name__} : [\n{attrs}\n]>"
         return _string


### PR DESCRIPTION
## Summary
- `HumanName.__repr__` mixed tab and space indentation and had inconsistent trailing spaces across attribute lines (some fields carried a stray trailing space before the newline, others didn't)
- Standardized on 4-space indentation with no trailing whitespace
- Updated the example blocks in README.rst, docs/usage.rst, and docs/customize.rst to match the real output

## Test plan
- [x] `pytest -q` — 1270 passed, 4 skipped, 22 xfailed (no change from baseline)
- [x] `sphinx -b doctest` — same pre-existing failure count as baseline (5 unrelated failures from global-state leakage between doctest blocks, not touched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)