### PR TITLE
Use uv in CI instead of pip

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,21 +28,21 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade "pip>=24.2" setuptools
-        python -m pip install build
-        python -m pip install twine
-        python -m pip install --group dev
+      run: uv sync --group dev
     - name: Run linter
-      run: ruff check
+      run: uv run ruff check
     - name: Check types
-      run: mypy
+      run: uv run mypy
     - name: Run Tests
       run: |
-        pytest
-        python -m build --sdist
-        twine check dist/*
-        sphinx-build -b html docs dist/docs
-        sphinx-build -b doctest docs dist/doctest
-        python -m doctest README.rst
+        uv run pytest
+        uv run --with build python -m build --sdist
+        uv run --with twine twine check dist/*
+        uv run sphinx-build -b html docs dist/docs
+        uv run sphinx-build -b doctest docs dist/doctest
+        uv run python -m doctest README.rst


### PR DESCRIPTION
## Summary
- Everywhere else in this repo (`AGENTS.md`, local dev commands) uses `uv run`, and there's already a committed `uv.lock` -- CI was the odd one out, using `pip install --group dev` which floats dependency versions on every run instead of installing the exact locked versions.
- Switched to `astral-sh/setup-uv` + `uv sync --group dev` (with caching enabled), and every subsequent command (`ruff`, `mypy`, `pytest`, `sphinx-build`, `python -m doctest`) now runs via `uv run` for consistency and speed.
- `build`/`twine` aren't part of the project's `dev` dependency group, so they use `uv run --with <tool>` for ephemeral installation rather than adding packaging-only tools to the lockfile.

## Test plan
- [x] `uv sync --group dev` — resolves and installs cleanly from the lockfile
- [x] `uv run ruff check` — passes
- [x] `uv run mypy` — passes
- [x] `uv run pytest` — 1274 passed, 22 xfailed
- [x] `uv run --with build python -m build --sdist` + `uv run --with twine twine check dist/*` — builds and passes
- [x] `uv run sphinx-build -b html docs dist/docs` — builds
- [x] `uv run sphinx-build -b doctest docs dist/doctest` — 186/186 passed
- [x] `uv run python -m doctest README.rst` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)