### PR TITLE
Don't setLevel on the library logger

### DIFF
--- a/nameparser/util.py
+++ b/nameparser/util.py
@@ -4,7 +4,6 @@ from typing import Literal
 # http://code.google.com/p/python-nameparser/issues/detail?id=10
 log = logging.getLogger('HumanName')
 log.addHandler(logging.NullHandler())
-log.setLevel(logging.ERROR)
 
 
 HumanNameAttributeT = Literal['title', 'first', 'middle', 'last', 'suffix', 'nickname', 'surnames']


### PR DESCRIPTION
## Summary
- `nameparser/util.py` called `log.setLevel(logging.ERROR)` on the `HumanName` logger at import time, which silently discards log records regardless of how the application configures its root/child logger levels.
- Libraries should attach a handler (already done via `NullHandler`) but leave the level at `NOTSET` so applications control verbosity.
- `__main__.py` keeps its own explicit `setLevel(logging.ERROR)` for CLI use, which is unaffected.

Fixes #228

## Test plan
- [x] `python -m pytest -q` — 1340 passed, 4 skipped, 22 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)