### PR TITLE
Modernize config constant data structures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ The library has two layers: `nameparser/config/` (data) and `nameparser/parser.p
 
 ### Configuration layer (`nameparser/config/`)
 
-Each module defines a plain Python set of known name pieces:
+Most modules define a plain Python set of known name pieces; `capitalization.py` and `regexes.py` define dicts:
 
 - `titles.py` — `TITLES` (prenominals) and `FIRST_NAME_TITLES` (e.g. "Sir", which treat the following name as first, not last)
 - `suffixes.py` — `SUFFIX_ACRONYMS` (with periods, e.g. "M.D.") and `SUFFIX_NOT_ACRONYMS` (e.g. "Jr.")
@@ -81,7 +81,7 @@ Each module defines a plain Python set of known name pieces:
 - `bound_first_names.py` — `BOUND_FIRST_NAMES` (bound given-name prefixes, e.g. "abdul", "abu"); `_join_bound_first_name` joins the first non-title piece to its following piece before the main assignment loop
 - `conjunctions.py` — `CONJUNCTIONS` (e.g. "and", "of") used to chain multi-word titles
 - `capitalization.py` — `CAPITALIZATION_EXCEPTIONS` mapping (e.g. `{'phd': 'Ph.D.'}`)
-- `regexes.py` — compiled regular expressions wrapped in a `TupleManager`
+- `regexes.py` — dict of compiled regular expressions (wrapped in `RegexTupleManager` by `Constants`)
 
 `config/__init__.py` wraps everything into `SetManager` and `TupleManager` instances inside a `Constants` class. A module-level singleton `CONSTANTS` is shared across all `HumanName` instances by default.
 

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -53,9 +53,11 @@ Editable attributes of nameparser.config.CONSTANTS
 * :py:data:`~nameparser.config.CAPITALIZATION_EXCEPTIONS` - Dictionary of pieces that do not capitalize the first letter, e.g. "Ph.D".
 * :py:data:`~nameparser.config.REGEXES` - Regular expressions used to find words, initials, nicknames, etc.
 
-Each set of constants comes with :py:func:`~nameparser.config.SetManager.add` and :py:func:`~nameparser.config.SetManager.remove` methods for tuning
+Each set-valued constant comes with :py:func:`~nameparser.config.SetManager.add` and :py:func:`~nameparser.config.SetManager.remove` methods for tuning
 the constants for your project. These methods automatically lower case and
-remove punctuation to normalize them for comparison.
+remove punctuation to normalize them for comparison. The two dict-valued
+constants (``CAPITALIZATION_EXCEPTIONS`` and ``REGEXES``) are edited with
+normal dict operations.
 
 Adding Custom Nickname Delimiters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/release_log.rst
+++ b/docs/release_log.rst
@@ -43,6 +43,7 @@ Release Log
     - Add German/Austrian nobility and ecclesiastical titles to ``TITLES`` (closes #101)
     - Add German/Dutch last-name prefixes and title/degree suffixes; fix ``join_on_conjunctions()`` to register multi-word prefix chains (e.g. ``"von und zu"``) as prefixes, mirroring existing title handling (closes #18)
     - Change ``Constants.__repr__`` to report collection sizes and non-default scalar config, replacing the uninformative ``<Constants() instance>`` (#221)
+    - Change ``REGEXES`` from a ``set`` of ``(name, pattern)`` tuples to a ``dict``, so a duplicate name is a visible overwrite in the source instead of a nondeterministic winner at import time; code iterating ``REGEXES`` directly now gets keys instead of pairs — use ``.items()`` (#227)
 * 1.2.1 - June 19, 2026
     - Fix ``initials()`` interpolating the literal ``None`` for empty name parts when ``empty_attribute_default = None`` (e.g. ``"J. None D."``); empty parts now render as an empty string and a fully-empty result returns ``empty_attribute_default``
     - Add ``python -m nameparser "Name String"`` command-line helper that prints a parsed name

--- a/docs/release_log.rst
+++ b/docs/release_log.rst
@@ -44,7 +44,7 @@ Release Log
     - Add German/Dutch last-name prefixes and title/degree suffixes; fix ``join_on_conjunctions()`` to register multi-word prefix chains (e.g. ``"von und zu"``) as prefixes, mirroring existing title handling (closes #18)
     - Change ``Constants.__repr__`` to report collection sizes and non-default scalar config, replacing the uninformative ``<Constants() instance>`` (#221)
     - Change ``REGEXES`` from a ``set`` of ``(name, pattern)`` tuples to a ``dict``, so a duplicate name is a visible overwrite in the source instead of a nondeterministic winner at import time; code iterating ``REGEXES`` directly now gets keys instead of pairs — use ``.items()`` (#227)
-    - Change ``CAPITALIZATION_EXCEPTIONS`` from a tuple of ``(key, value)`` tuples to a ``dict``; code iterating it directly now gets keys instead of pairs — use ``.items()``
+    - Change ``CAPITALIZATION_EXCEPTIONS`` from a tuple of ``(key, value)`` tuples to a ``dict``; code iterating it directly now gets keys instead of pairs — use ``.items()`` (#233)
 * 1.2.1 - June 19, 2026
     - Fix ``initials()`` interpolating the literal ``None`` for empty name parts when ``empty_attribute_default = None`` (e.g. ``"J. None D."``); empty parts now render as an empty string and a fully-empty result returns ``empty_attribute_default``
     - Add ``python -m nameparser "Name String"`` command-line helper that prints a parsed name

--- a/docs/release_log.rst
+++ b/docs/release_log.rst
@@ -44,6 +44,7 @@ Release Log
     - Add German/Dutch last-name prefixes and title/degree suffixes; fix ``join_on_conjunctions()`` to register multi-word prefix chains (e.g. ``"von und zu"``) as prefixes, mirroring existing title handling (closes #18)
     - Change ``Constants.__repr__`` to report collection sizes and non-default scalar config, replacing the uninformative ``<Constants() instance>`` (#221)
     - Change ``REGEXES`` from a ``set`` of ``(name, pattern)`` tuples to a ``dict``, so a duplicate name is a visible overwrite in the source instead of a nondeterministic winner at import time; code iterating ``REGEXES`` directly now gets keys instead of pairs — use ``.items()`` (#227)
+    - Change ``CAPITALIZATION_EXCEPTIONS`` from a tuple of ``(key, value)`` tuples to a ``dict``; code iterating it directly now gets keys instead of pairs — use ``.items()``
 * 1.2.1 - June 19, 2026
     - Fix ``initials()`` interpolating the literal ``None`` for empty name parts when ``empty_attribute_default = None`` (e.g. ``"J. None D."``); empty parts now render as an empty string and a fully-empty result returns ``empty_attribute_default``
     - Add ``python -m nameparser "Name String"`` command-line helper that prints a parsed name

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -154,8 +154,10 @@ def _is_dunder(attr: str) -> bool:
 
 class TupleManager(dict[str, T]):
     '''
-    A dictionary with dot.notation access. Subclass of ``dict``. Makes the tuple constants
-    more friendly.
+    A dictionary with dot.notation access. Subclass of ``dict``. Wraps the
+    mapping config constants (``capitalization_exceptions``, ``regexes``, and
+    the nickname/maiden delimiter buckets). The name is historical: before
+    1.3.0 these constants were tuples of pairs.
     '''
 
     def __getattr__(self, attr: str) -> T | None:
@@ -276,9 +278,9 @@ class Constants:
     :type capitalization_exceptions: dict or iterable of (key, value) tuples
     :param capitalization_exceptions:
         :py:attr:`~capitalization.CAPITALIZATION_EXCEPTIONS` wrapped with :py:class:`TupleManager`.
-    :type regexes: dict or iterable of (key, value) tuples
+    :type regexes: dict or iterable of (name, compiled pattern) tuples
     :param regexes:
-        :py:attr:`regexes`  wrapped with :py:class:`TupleManager`.
+        :py:attr:`~regexes.REGEXES` wrapped with :py:class:`RegexTupleManager`.
 
     :py:attr:`nickname_delimiters` and :py:attr:`maiden_delimiters` are not
     constructor arguments -- they're always set in ``__init__`` (see the

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -477,7 +477,7 @@ class Constants:
                  bound_first_names: Iterable[str] = BOUND_FIRST_NAMES,
                  non_first_name_prefixes: Iterable[str] = NON_FIRST_NAME_PREFIXES,
                  capitalization_exceptions: TupleManager[str] | Iterable[tuple[str, str]] = CAPITALIZATION_EXCEPTIONS,
-                 regexes: RegexTupleManager | TupleManager[re.Pattern[str]] | Iterable[tuple[str, re.Pattern[str]]] = REGEXES,
+                 regexes: Mapping[str, re.Pattern[str]] | Iterable[tuple[str, re.Pattern[str]]] = REGEXES,
                  patronymic_name_order: bool = False,
                  middle_name_as_last: bool = False,
                  ) -> None:

--- a/nameparser/config/__init__.py
+++ b/nameparser/config/__init__.py
@@ -273,11 +273,11 @@ class Constants:
         The subset of prefixes that are never a first name, so a *leading* one
         marks the whole name as a surname. Must stay disjoint from
         ``bound_first_names``.
-    :type capitalization_exceptions: tuple or dict
-    :param capitalization_exceptions: 
+    :type capitalization_exceptions: dict or iterable of (key, value) tuples
+    :param capitalization_exceptions:
         :py:attr:`~capitalization.CAPITALIZATION_EXCEPTIONS` wrapped with :py:class:`TupleManager`.
-    :type regexes: tuple or dict
-    :param regexes: 
+    :type regexes: dict or iterable of (key, value) tuples
+    :param regexes:
         :py:attr:`regexes`  wrapped with :py:class:`TupleManager`.
 
     :py:attr:`nickname_delimiters` and :py:attr:`maiden_delimiters` are not
@@ -476,7 +476,7 @@ class Constants:
                  conjunctions: Iterable[str] = CONJUNCTIONS,
                  bound_first_names: Iterable[str] = BOUND_FIRST_NAMES,
                  non_first_name_prefixes: Iterable[str] = NON_FIRST_NAME_PREFIXES,
-                 capitalization_exceptions: TupleManager[str] | Iterable[tuple[str, str]] = CAPITALIZATION_EXCEPTIONS,
+                 capitalization_exceptions: Mapping[str, str] | Iterable[tuple[str, str]] = CAPITALIZATION_EXCEPTIONS,
                  regexes: Mapping[str, re.Pattern[str]] | Iterable[tuple[str, re.Pattern[str]]] = REGEXES,
                  patronymic_name_order: bool = False,
                  middle_name_as_last: bool = False,

--- a/nameparser/config/capitalization.py
+++ b/nameparser/config/capitalization.py
@@ -1,10 +1,10 @@
-CAPITALIZATION_EXCEPTIONS = (
-    ('ii', 'II'),
-    ('iii', 'III'),
-    ('iv', 'IV'),
-    ('md', 'M.D.'),
-    ('phd', 'Ph.D.'),
-)
+CAPITALIZATION_EXCEPTIONS = {
+    'ii': 'II',
+    'iii': 'III',
+    'iv': 'IV',
+    'md': 'M.D.',
+    'phd': 'Ph.D.',
+}
 """
 Any pieces that are not capitalized by capitalizing the first letter.
 """

--- a/nameparser/config/conjunctions.py
+++ b/nameparser/config/conjunctions.py
@@ -1,4 +1,4 @@
-CONJUNCTIONS = set([
+CONJUNCTIONS = {
     '&',
     'and',
     'et',
@@ -7,7 +7,7 @@ CONJUNCTIONS = set([
     'the',
     'und',
     'y',
-])
+}
 """
 Pieces that should join to their neighboring pieces, e.g. "and", "y" and "&".
 "of" and "the" are also include to facilitate joining multiple titles,

--- a/nameparser/config/prefixes.py
+++ b/nameparser/config/prefixes.py
@@ -9,7 +9,7 @@ from nameparser.config.bound_first_names import BOUND_FIRST_NAMES
 #: means that name is not auto-fixed, whereas a wrong member misparses a real
 #: person. Must stay a subset of :py:data:`PREFIXES` and disjoint from
 #: :py:data:`~nameparser.config.bound_first_names.BOUND_FIRST_NAMES`.
-NON_FIRST_NAME_PREFIXES = set([
+NON_FIRST_NAME_PREFIXES = {
     "'t",
     'af',
     'auf',
@@ -32,7 +32,7 @@ NON_FIRST_NAME_PREFIXES = set([
     'vd',
     'vom',
     'zu',
-])
+}
 
 #: Name pieces that appear before a last name. Prefixes join to the piece
 #: that follows them to make one new piece. They can be chained together, e.g
@@ -48,7 +48,7 @@ NON_FIRST_NAME_PREFIXES = set([
 #: is guaranteed to also be a prefix (and still join forward), with no drift --
 #: mirroring ``TITLES = FIRST_NAME_TITLES | {...}`` in
 #: :py:mod:`nameparser.config.titles`.
-PREFIXES = NON_FIRST_NAME_PREFIXES | set([
+PREFIXES = NON_FIRST_NAME_PREFIXES | {
     'aan',
     'aen',
     'abu',
@@ -86,7 +86,7 @@ PREFIXES = NON_FIRST_NAME_PREFIXES | set([
     'vander',
     'vel',
     'von',
-])
+}
 
 # Guard the two invariants the docstring above promises, so a future edit that
 # breaks them fails at import time instead of silently drifting until a test

--- a/nameparser/config/regexes.py
+++ b/nameparser/config/regexes.py
@@ -8,39 +8,39 @@ re_emoji = re.compile('['  # lgtm[py/overly-large-range]
 
 EMPTY_REGEX = re.compile('')
 
-REGEXES = set([
-    ("spaces", re.compile(r"\s+")),
-    ("word", re.compile(r"(\w|\.)+")),
-    ("mac", re.compile(r'^(ma?c)(\w{2,})', re.I)),
-    ("initial", re.compile(r'^(\w\.|[A-Z])?$')),
-    ("quoted_word", re.compile(r'(?<!\w)\'([^\s]*?)\'(?!\w)')),
-    ("double_quotes", re.compile(r'\"(.*?)\"')),
-    ("parenthesis", re.compile(r'\((.*?)\)')),
-    ("roman_numeral", re.compile(r'^(X|IX|IV|V?I{0,3})$', re.I)),
-    ("no_vowels",re.compile(r'^[^aeyiuo]+$', re.I)),
-    ("period_not_at_end",re.compile(r'.*\..+$', re.I)),
-    ("emoji",re_emoji),
-    ("phd", re.compile(r'\s(ph\.?\s+d\.?)', re.I)),
-    ("space_before_comma", re.compile(r'\s+,')),
-    ("east_slavic_patronymic", re.compile(
+REGEXES = {
+    "spaces": re.compile(r"\s+"),
+    "word": re.compile(r"(\w|\.)+"),
+    "mac": re.compile(r'^(ma?c)(\w{2,})', re.I),
+    "initial": re.compile(r'^(\w\.|[A-Z])?$'),
+    "quoted_word": re.compile(r'(?<!\w)\'([^\s]*?)\'(?!\w)'),
+    "double_quotes": re.compile(r'\"(.*?)\"'),
+    "parenthesis": re.compile(r'\((.*?)\)'),
+    "roman_numeral": re.compile(r'^(X|IX|IV|V?I{0,3})$', re.I),
+    "no_vowels": re.compile(r'^[^aeyiuo]+$', re.I),
+    "period_not_at_end": re.compile(r'.*\..+$', re.I),
+    "emoji": re_emoji,
+    "phd": re.compile(r'\s(ph\.?\s+d\.?)', re.I),
+    "space_before_comma": re.compile(r'\s+,'),
+    "east_slavic_patronymic": re.compile(
         r'(ovich|ovna|evich|evna|ichna|ilyich|kuzmich|lukich|fomich|fokich)$',
         re.I,
-    )),
-    ("east_slavic_patronymic_cyrillic", re.compile(
+    ),
+    "east_slavic_patronymic_cyrillic": re.compile(
         r'(ович|овна|евич|евна|ична|ильич|кузьмич|лукич|фомич|фокич)$',
         re.I,
-    )),
-    ("turkic_patronymic_marker", re.compile(
+    ),
+    "turkic_patronymic_marker": re.compile(
         r"^(oglu|oğlu|ogly|ogli|o['’ʻ]g['’ʻ]li"
         r"|qizi|qızı|kizi|kyzy|gyzy|uly|uulu)$",
         re.I,
-    )),
-    ("turkic_patronymic_marker_cyrillic", re.compile(
+    ),
+    "turkic_patronymic_marker_cyrillic": re.compile(
         r'^(оглу|оглы|оғлу|ўғли|угли|кызы|гызы|қызы|қизи|улы|ұлы|уулу)$',
         re.I,
-    )),
-    ("period_abbreviation", re.compile(r'^[^\W\d_]{2,}\.$')),
-])
+    ),
+    "period_abbreviation": re.compile(r'^[^\W\d_]{2,}\.$'),
+}
 """
 All regular expressions used by the parser are precompiled and stored in the config.
 """

--- a/nameparser/config/suffixes.py
+++ b/nameparser/config/suffixes.py
@@ -1,4 +1,4 @@
-SUFFIX_NOT_ACRONYMS = set([
+SUFFIX_NOT_ACRONYMS = {
     'dr',
     'esq',
     'esquire',
@@ -21,14 +21,14 @@ SUFFIX_NOT_ACRONYMS = set([
     # literally instead of going through nickname/suffix disambiguation).
     'ret',
     'vet',
-])
+}
 """
 
 Post-nominal pieces that are not acronyms. The parser does not remove periods
 when matching against these pieces.
 
 """
-SUFFIX_ACRONYMS_AMBIGUOUS = set([
+SUFFIX_ACRONYMS_AMBIGUOUS = {
     # Suffix acronyms that also commonly work as given-name nicknames on
     # their own (e.g. "Ed", "JD"). Read only by HumanName.parse_nicknames()
     # when deciding whether parenthesized/quoted content is a nickname or a
@@ -42,7 +42,7 @@ SUFFIX_ACRONYMS_AMBIGUOUS = set([
     # certifications/degrees (e.g. 'mba', 'cpa', 'phd') don't need an entry.
     'ed',
     'jd',
-])
+}
 """
 
 Acronym suffixes from SUFFIX_ACRONYMS that also plausibly collide with a
@@ -50,7 +50,7 @@ common given-name nickname. Not a partition of SUFFIX_ACRONYMS -- a small,
 standalone exception list consulted only by parse_nicknames().
 
 """
-SUFFIX_ACRONYMS = set([
+SUFFIX_ACRONYMS = {
     '8-vsb',
     'aas',
     'aba',
@@ -683,7 +683,7 @@ SUFFIX_ACRONYMS = set([
     'vcp',
     'vd',
     'vrd',
-])
+}
 """
 
 Post-nominal acronyms. Titles, degrees and other things people stick after their name

--- a/nameparser/config/titles.py
+++ b/nameparser/config/titles.py
@@ -1,4 +1,4 @@
-FIRST_NAME_TITLES = set([
+FIRST_NAME_TITLES = {
     'aunt',
     'auntie',
     'brother',
@@ -21,7 +21,7 @@ FIRST_NAME_TITLES = set([
     'shaikh',
     'cheikh',
     'shekh',
-])
+}
 """
 When these titles appear with a single other name, that name is a first name, e.g.
 "Sir John", "Sister Mary", "Queen Elizabeth".
@@ -31,7 +31,7 @@ When these titles appear with a single other name, that name is a first name, e.
 #: Many of these from wikipedia: https://en.wikipedia.org/wiki/Title.
 #: The parser recognizes chains of these including conjunctions allowing 
 #: recognition titles like "Deputy Secretary of State".
-TITLES = FIRST_NAME_TITLES | set([
+TITLES = FIRST_NAME_TITLES | {
     "attaché",
     "chargé d'affaires",
     "king's",
@@ -683,4 +683,4 @@ TITLES = FIRST_NAME_TITLES | set([
     'woodman',
     'writer',
     'zoologist',
-])
+}


### PR DESCRIPTION
Closes #227, expanded to cover all the Python 2-era data structures in `nameparser/config`. Three commits, ordered from behavior-relevant to purely cosmetic:

## 1. `REGEXES`: set of `(name, pattern)` tuples → dict (#227)

`REGEXES` was a `set` of tuples consumed as `dict(...)` by `RegexTupleManager`. If two entries ever shared a name, which one won was nondeterministic per process (set iteration order varies with hash randomization). A dict literal makes a duplicate key a visible overwrite at write time.

## 2. `CAPITALIZATION_EXCEPTIONS`: tuple of tuples → dict

Same rationale minus the nondeterminism (tuples are ordered, so last-wins was at least deterministic — just silent). The docs already described it as a dictionary; now the code agrees.

## 3. `set([...])` → set literals

`CONJUNCTIONS`, `FIRST_NAME_TITLES`, `TITLES`, `NON_FIRST_NAME_PREFIXES`, `PREFIXES`, and the three `SUFFIX_*` constants used the pre-2.7 `set([...])`-around-a-list form. Purely cosmetic; contents verified element-for-element identical against master for all eight.

## Supporting changes

- `Constants.__init__` annotations for `regexes` and `capitalization_exceptions` collapse to `Mapping[...] | Iterable[tuple[...]]` — the old `TupleManager` union arms were `dict` subclasses already covered by `Mapping`, and the plain-dict defaults require it
- Release log entries for the two observable changes, each with the compat note: code iterating `REGEXES` or `CAPITALIZATION_EXCEPTIONS` directly now gets keys instead of pairs — use `.items()`

## Verification

- `uv run pytest`: 1344 passed, 22 xfailed (after each commit)
- `uv run mypy`: no issues in 13 source files
- Set-literal sweep additionally verified by importing each config module from master and from the branch and asserting all eight constants compare equal



## 4. Documentation accuracy pass

A multi-agent review of the diff surfaced prose made stale by the conversions (plus a few adjacent pre-existing imprecisions): the `TupleManager` docstring's reference to "the tuple constants", the `:param regexes:` line naming the wrong wrapper class, AGENTS.md's description of the config modules, a missing release-log issue reference, and customize.rst promising `add()`/`remove()` on the dict-valued constants. All fixed in the final commit; Sphinx builds warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
