### PR TITLE
Add bound_first_names to the config defaults automodule list

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -29,6 +29,8 @@ HumanName.config Defaults
     :members:
 .. automodule:: nameparser.config.prefixes
     :members:
+.. automodule:: nameparser.config.bound_first_names
+    :members:
 .. automodule:: nameparser.config.conjunctions
     :members:
 .. automodule:: nameparser.config.capitalization


### PR DESCRIPTION
`docs/modules.rst` has `automodule` entries for six of the seven config modules; `nameparser.config.bound_first_names` (added in v1.3.0) was missing, so Sphinx references like `~bound_first_names.BOUND_FIRST_NAMES` in the `Constants` class docstring had no target.

One-line fix: add the missing entry, placed after `prefixes` to match the module ordering used in AGENTS.md.

## Verification

- `uv run sphinx-build -b html docs ...`: build succeeded, no warnings
- Nitpicky build (`-n`): unresolved `BOUND_FIRST_NAMES` references go from 2 on master to 0 on this branch
- The one remaining `bound_first_names`-adjacent nitpicky warning (`Constants.bound_first_names`) is the pre-existing annotation-only-attribute pattern shared by `Constants.regexes` etc., unrelated to this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)