### PR TITLE
Fix IndexError in initials for unnormalized *_list elements

### DIFF
--- a/docs/release_log.rst
+++ b/docs/release_log.rst
@@ -1,6 +1,7 @@
 Release Log
 ===========
 * 1.3.0 - Unreleased
+    - Fix ``IndexError`` in ``initials()``/``initials_list()`` when a ``*_list`` attribute was assigned directly with an element containing unnormalized whitespace (e.g. ``name.middle_list = ['Q  R']``), bypassing the parser's whitespace normalization (closes #232)
     - Fix ``HumanName`` acting as its own iterator with a stored cursor: breaking out of a loop, iterating in nested loops, or calling ``len(name)`` mid-loop corrupted subsequent iteration; ``iter(name)`` now returns a fresh independent iterator each time. ``next(name)`` on the instance itself (undocumented) now raises ``TypeError`` — call ``next(iter(name))`` instead (closes #225)
     - Fix parsing writing back into the ``Constants`` it reads (usually the shared module-level ``CONSTANTS``): pieces derived while parsing a name — period-joined titles/suffixes like ``"Lt.Gov."`` and conjunction-joined pieces like ``"Mr. and Mrs."`` or ``"von und zu"`` — are now tracked per parse instead of being permanently ``add()``-ed to the config, so parse results no longer depend on which names were parsed earlier in the process and parsing no longer mutates shared state across threads
     - Remove the vestigial ``unparsable`` attribute: the guard that was meant to set it has been unreachable since 2013 (v0.2.9), so it has reported ``False`` for every parsed name for over a decade; check ``len(name) == 0`` to detect an empty parse

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -250,7 +250,10 @@ class HumanName:
             Name parts may include prefixes or conjunctions. This function filters these from the name unless it is
             a first name, since first names cannot be conjunctions or prefixes.
         """
-        parts = name_part.split(" ")
+        # split() rather than split(" "): *_list attributes assigned directly
+        # bypass parse_pieces whitespace normalization, and split(" ") yields
+        # empty strings for repeated spaces (#232)
+        parts = name_part.split()
         initials = []
         for part in parts:
             if not (self.is_prefix(part) or self.is_conjunction(part)) or firstname:

--- a/tests/test_initials.py
+++ b/tests/test_initials.py
@@ -134,6 +134,15 @@ class InitialsTestCase(HumanNameTestBase):
         hn = HumanName("John Doe")
         self.assertEqual(str(hn), "John Doe")
 
+    def test_initials_with_doubled_space_in_list_element(self) -> None:
+        # direct *_list assignment bypasses parse_pieces whitespace
+        # normalization, so initials must tolerate unnormalized elements
+        # instead of raising IndexError (#232)
+        hn = HumanName(first="John")
+        hn.middle_list = ["Q  R"]
+        self.assertEqual(hn.initials_list(), ["J", "Q R"])
+        self.assertEqual(hn.initials(), "J. Q R.")
+
     def test_constructor_first(self) -> None:
         hn = HumanName(first="TheName")
         self.m(hn.first, "TheName", hn)


### PR DESCRIPTION
## Summary
- `_process_initial` split name parts with `split(" ")`, so an element containing a doubled space (e.g. `name.middle_list = ['Q  R']`) produced an empty-string part and `part[0]` raised `IndexError` (closes #232)
- Only direct assignment to the `*_list` attributes hits this — the normal constructor/property paths go through `parse_pieces`, which normalizes whitespace before elements reach the initials code
- Fix is bare `split()`: identical to `split(" ")` for normalized input, never yields empty strings, and also tolerates tabs/newlines/leading/trailing whitespace; whitespace-only elements now yield no initials and are dropped by the existing caller-side filter

## Test plan
- New test written first (TDD): verified failing with the exact `IndexError` from the issue before the fix, asserting the doubled-space element produces the same initials as its single-space equivalent
- Full suite: 1342 passed, 4 skipped, 22 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)