### PR TITLE
Fix stale maiden-field docs in index.rst and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,18 @@ You can also pass a name string to see how it will be parsed:
     	last: 'Rodham-Clinton'
     	suffix: ''
     	nickname: ''
+    	maiden: ''
     ]>
+    <HumanName : [
+    	title: 'Secretary of State'
+    	first: 'Hillary'
+    	middle: ''
+    	last: 'Rodham-Clinton'
+    	suffix: ''
+    	nickname: ''
+    	maiden: ''
+    ]>
+    Initials: H. R.
 
 CI runs tests against Python 3.10–3.14 via GitHub Actions on every push and pull request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,12 @@ Run a single test file or test:
 
 You can also pass a name string to see how it will be parsed:
 
-    $ python -m nameparser "Secretary of State Hillary Rodham-Clinton"
+    $ python -m nameparser "secretary of state hillary rodham-clinton"
     <HumanName : [
-    	title: 'Secretary of State'
-    	first: 'Hillary'
+    	title: 'secretary of state'
+    	first: 'hillary'
     	middle: ''
-    	last: 'Rodham-Clinton'
+    	last: 'rodham-clinton'
     	suffix: ''
     	nickname: ''
     	maiden: ''

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ components.
 * hn.last
 * hn.suffix
 * hn.nickname
+* hn.maiden
 
 Supports 3 different comma placement variations in the input string.
 


### PR DESCRIPTION
## Summary
- The `maiden` field was added to `HumanName` in 1.3.0 (closes #22) — every `HumanName` repr has included it since, but two docs were never updated to match:
  - `docs/index.rst`: the attribute bullet list was missing `hn.maiden`.
  - `CONTRIBUTING.md`: the `python -m nameparser "..."` debug-CLI example output was stale in three ways versus what `nameparser/__main__.py` actually prints — missing the `maiden: ''` repr line, missing the second `repr()` block (the CLI calls `.capitalize()` and prints again), and missing the trailing `Initials: H. R.` line.
- Fixed by pasting in the actual current output of `python -m nameparser "Secretary of State Hillary Rodham-Clinton"`, matching the file's existing indentation (4 spaces + tab per field).

## Test plan
- [x] `python -m nameparser "Secretary of State Hillary Rodham-Clinton"` output matches CONTRIBUTING.md verbatim
- [x] `uv run sphinx-build -b doctest docs <tmpdir>` — 191 tests, 0 failures
- [x] `uv run sphinx-build -b html docs <tmpdir>` — build succeeded
- [x] `pytest` — 1438 passed, 4 skipped, 22 xfailed