### PR TITLE
Strip invisible bidi control characters during preprocessing

### DIFF
--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -501,6 +501,24 @@ You can turn this off by setting the ``emoji`` regex to ``False``.
     >>> str(hn)
     'Sam 😊 Smith'
 
+Don't Remove Bidi Control Characters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, invisible bidirectional control characters (the left-to-right and
+right-to-left marks and friends, common in copy-pasted right-to-left names) are
+removed from the input string before the name is parsed. You can turn this off
+by setting the ``bidi`` regex to ``False``.
+
+.. doctest::
+
+    >>> from nameparser import HumanName
+    >>> from nameparser.config import Constants
+    >>> constants = Constants()
+    >>> constants.regexes.bidi = False
+    >>> hn = HumanName("\u200fJohn\u200f Smith", constants=constants)
+    >>> hn.first == "\u200fJohn\u200f"
+    True
+
 Config Changes May Need Parse Refresh
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/release_log.rst
+++ b/docs/release_log.rst
@@ -1,5 +1,9 @@
 Release Log
 ===========
+* 1.3.1 - Unreleased
+
+    - Fix invisible Unicode bidirectional control characters (LRM/RLM/ALM, the embedding/override marks, and the isolates U+2066–U+2069) surviving parsing and sticking to ``first``/``last``/etc., so a copy-pasted right-to-left name silently failed equality and dedup. They are now stripped in preprocessing like emoji; disable via ``CONSTANTS.regexes.bidi = False`` (closes #266)
+
 * 1.3.0 - July 5, 2026
 
     **Breaking Changes & Deprecations**

--- a/nameparser/config/regexes.py
+++ b/nameparser/config/regexes.py
@@ -6,6 +6,12 @@ re_emoji = re.compile('['  # lgtm[py/overly-large-range]
     '\U0001F680-\U0001F6FF'
     '\u2600-\u26FF\u2700-\u27BF]+')
 
+# Invisible bidirectional formatting characters: ALM, LRM, RLM, the
+# embedding/override marks (LRE/RLE/PDF/LRO/RLO) and the isolates
+# (LRI/RLI/FSI/PDI). Copy-pasted RTL names often carry these; they render
+# as nothing but stick to name parts and break equality/lookups.
+re_bidi = re.compile('[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]+')
+
 EMPTY_REGEX = re.compile('')
 
 REGEXES = {
@@ -20,6 +26,7 @@ REGEXES = {
     "no_vowels": re.compile(r'^[^aeyiuo]+$', re.I),
     "period_not_at_end": re.compile(r'.*\..+$', re.I),
     "emoji": re_emoji,
+    "bidi": re_bidi,
     "phd": re.compile(r'\s(ph\.?\s+d\.?)', re.I),
     "space_before_comma": re.compile(r'\s+,'),
     "east_slavic_patronymic": re.compile(

--- a/nameparser/parser.py
+++ b/nameparser/parser.py
@@ -928,9 +928,11 @@ class HumanName:
         This method happens at the beginning of the :py:func:`parse_full_name`
         before any other processing of the string aside from unicode
         normalization, so it's a good place to do any custom handling in a
-        subclass. Runs :py:func:`parse_nicknames` and :py:func:`squash_emoji`.
+        subclass. Runs :py:func:`squash_bidi`, :py:func:`parse_nicknames` and
+        :py:func:`squash_emoji`.
 
         """
+        self.squash_bidi()
         self.fix_phd()
         self.parse_nicknames()
         self.squash_emoji()
@@ -1132,6 +1134,16 @@ class HumanName:
         re_emoji = self.C.regexes.emoji
         if re_emoji and re_emoji.search(self._full_name):
             self._full_name = re_emoji.sub('', self._full_name)
+
+    def squash_bidi(self) -> None:
+        """
+        Remove invisible bidirectional control characters from the input
+        string. They carry no name content but stick to the parts they
+        surround, so parsed attributes stop comparing equal to the clean name.
+        """
+        re_bidi = self.C.regexes.bidi
+        if re_bidi and re_bidi.search(self._full_name):
+            self._full_name = re_bidi.sub('', self._full_name)
 
     def handle_firstnames(self) -> None:
         """

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -136,3 +136,27 @@ class HumanNameOutputFormatTests(HumanNameTestBase):
         self.m(hn.last, "Smith😊", hn)
         self.assertEqual(str(hn), "∫≜⩕ Smith😊")
         # test cleanup
+
+    def test_remove_bidi_control_chars(self) -> None:
+        # LRM/RLM and friends ride along with copy-pasted names and stick to
+        # the parts they surround. Covers every character in the bidi set.
+        for mark in ("\u200e", "\u200f", "\u061c", "\u202a", "\u202b",
+                     "\u202c", "\u202d", "\u202e", "\u2066", "\u2067",
+                     "\u2068", "\u2069"):
+            hn = HumanName(mark + "John" + mark + " Smith")
+            self.m(hn.first, "John", hn)
+            self.m(hn.last, "Smith", hn)
+
+    def test_bidi_stripped_name_compares_equal(self) -> None:
+        # The reported symptom: an invisible RLM around an RTL name makes the
+        # parsed part fail equality against the clean string (issue #266).
+        hn = HumanName("\u200fمحمد بن سلمان\u200f")
+        self.assertEqual(hn.first, "محمد")
+
+    def test_keep_bidi_control_chars(self) -> None:
+        from nameparser.config import Constants
+        constants = Constants()
+        constants.regexes.bidi = False  # type: ignore[assignment]
+        hn = HumanName("\u200fJohn\u200f Smith", constants)
+        self.m(hn.first, "\u200fJohn\u200f", hn)
+        self.m(hn.last, "Smith", hn)


### PR DESCRIPTION
Ran into this with copy-pasted Arabic names. If a name has an invisible right-to-left mark on it (U+200F, really common when you copy out of a PDF or a webpage), it just stays. So `.first` comes back with the mark still attached and `HumanName("‏محمد‏").first == "محمد"` is False even though they look identical. Since you can't see the character, dedup and lookups break silently.

Handled it the same way emoji already are (#58): a small `bidi` regex and a `squash_bidi()` in `pre_process()`. Put it first so a mark sitting inside a word doesn't mess up the nickname/Ph.D. steps. On by default, set `CONSTANTS.regexes.bidi = False` to keep them.

I only stripped the bidi controls the issue lists, not every invisible char (ZWSP, BOM, and so on). Some of those actually do something (ZWJ especially), so I didn't want to nuke everything. Happy to widen it if you'd rather.

closes #266