### PR TITLE
Release v1.3.1

### DIFF
--- a/docs/release_log.rst
+++ b/docs/release_log.rst
@@ -1,6 +1,6 @@
 Release Log
 ===========
-* 1.3.1 - Unreleased
+* 1.3.1 - July 11, 2026
 
     - Fix invisible Unicode bidirectional control characters (LRM/RLM/ALM, the embedding/override marks, and the isolates U+2066–U+2069) surviving parsing and sticking to ``first``/``last``/etc., so a copy-pasted right-to-left name silently failed equality and dedup. They are now stripped in preprocessing like emoji; disable via ``CONSTANTS.regexes.bidi = False`` (closes #266)
     - Fix ``str()`` corrupting name text containing the substring ``"None"`` when ``empty_attribute_default`` is ``None`` (e.g. ``"Nonez Smith"`` rendered as ``"z Smith"``): empty attributes are now substituted as ``''`` before the format string is applied, instead of scrubbing the interpolated ``"None"`` from the output afterward (closes #254)

--- a/nameparser/_version.py
+++ b/nameparser/_version.py
@@ -1,2 +1,2 @@
-VERSION = (1, 3, 0)
+VERSION = (1, 3, 1)
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
Release prep for v1.3.1: bump `nameparser/_version.py` to `(1, 3, 1)` and date the release log entry (July 11, 2026).

Patch release contents (already on master):
- #266 — strip invisible bidi control characters during preprocessing (#276)
- #254 — fix `str()` scrubbing literal `"None"` from real names when `empty_attribute_default` is `None` (#277)

After merge: tag `v1.3.1` and publish the GitHub release, which triggers the PyPI publish workflow (deploy requires manual approval on the `pypi` environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)