### PR TITLE
Make unexpected warnings test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,15 @@ python_classes = ["*Tests", "*TestCase"]
 # Fail if an xfail-marked test unexpectedly passes, so a fixed/regressed
 # expectation surfaces instead of silently turning into an xpass.
 xfail_strict = true
+# Unexpected warnings are failures: warnings are load-bearing API in 2.0
+# (the multi-word-entry UserWarning, the facade deprecation warnings), and
+# without this a warning regression is invisible to the suite -- a real
+# bug (eight spurious warnings on restoring a 1.4 Constants pickle)
+# shipped to review this way. Tests that EXPECT a warning assert it with
+# pytest.warns; targeted ignores below need a comment justifying each.
+filterwarnings = [
+    "error",
+]
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
## Summary

- Adds `filterwarnings = ["error"]` to the pytest config, so any unexpected warning during the suite is a test failure. Warnings are load-bearing API in 2.0 (the multi-word-entry `UserWarning`, the facade deprecation warnings), and without this a warning regression is invisible — the eight spurious warnings on restoring a 1.4 `Constants` pickle shipped all the way to the final PR #290 review this way, with 2,393 tests green around it.
- Zero fallout: the suite is already warning-disciplined (every legitimately-warning path asserts via `pytest.warns` or a local `simplefilter("error")` block), so no ignore entries and no test changes were needed. The list stays a bare `"error"` — the narrowest possible end state.
- Guard verified non-vacuous both ways: a scratch reproduction of the historical pickle bug now fails the run (with the correct `--rootdir`; a scratchpad-rooted run silently skips `pyproject.toml` — noted for anyone re-verifying), and the guard reaches `--doctest-modules` items too.

## Test Plan

- [x] `uv run pytest -q` — 2393 passed, 5 skipped, 11 xfailed (identical to baseline)
- [x] `uv run mypy` / `uv run ruff check nameparser/` clean
- [x] `uv run sphinx-build -b doctest docs` — 177 tests, 0 failures
- [x] Poison test: a stray `warnings.warn` in a test file fails the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)