### PR TITLE
Document FAMILY_FIRST_GIVEN_LAST, and fix the name-order example it exposed

### DIFF
--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -296,20 +296,20 @@ without going through a locale pack -- call :meth:`Policy.patched()
 Family-first name order
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-``name_order`` is the one most likely to matter for non-Western data.
-Positional input is assigned in the order you declare, so a
-family-first name parses as written instead of needing to be
-rearranged afterwards:
+``name_order`` is the one most likely to matter for data that is not
+in Western order. Positional input is assigned in the order you
+declare, so a name written family-first — Hungarian, here — parses as
+written instead of needing to be rearranged afterwards:
 
 .. doctest::
 
     >>> from nameparser import Parser, Policy, FAMILY_FIRST, parse
-    >>> parse("Nguyen Van Minh").family              # default GIVEN_FIRST
-    'Van Minh'
+    >>> parse("Nagy Laszlo Peter").family            # default GIVEN_FIRST
+    'Peter'
     >>> family_first = Parser(policy=Policy(name_order=FAMILY_FIRST))
-    >>> name = family_first.parse("Nguyen Van Minh")
-    >>> name.family, name.given
-    ('Nguyen', 'Van Minh')
+    >>> name = family_first.parse("Nagy Laszlo Peter")
+    >>> name.family, name.given, name.middle
+    ('Nagy', 'Laszlo', 'Peter')
 
 An explicit comma still wins, on the reasoning that someone who wrote
 one meant it — so the same parser reads ``"Thomas, John"`` as

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -320,6 +320,37 @@ family-then-given regardless of the configured order:
     >>> family_first.parse("Thomas, John").family
     'Thomas'
 
+A Vietnamese full name needs a third order. It is written family, then
+middle, then given — the name a person is actually called by is the
+*last* word, not the second. Family-first order gets the family name
+right and then reverses the remaining two, so
+``FAMILY_FIRST_GIVEN_LAST`` exists for the names that read this way:
+
+.. doctest::
+
+    >>> from nameparser import FAMILY_FIRST_GIVEN_LAST
+    >>> family_first.parse("Tran Quoc Toan").given       # FAMILY_FIRST
+    'Quoc'
+    >>> given_last = Parser(policy=Policy(name_order=FAMILY_FIRST_GIVEN_LAST))
+    >>> viet = given_last.parse("Tran Quoc Toan")
+    >>> viet.family, viet.middle, viet.given
+    ('Tran', 'Quoc', 'Toan')
+
+Nothing keys this order to a script the way the East Asian defaults
+below do — Vietnamese is written in the Latin alphabet, which carries
+no order of its own — so it applies only where you set it, and there
+is no ``vn`` locale pack yet (issue `#146
+<https://github.com/derek73/python-nameparser/issues/146>`_).
+
+One caution, which is why the example above is not the more obvious
+``"Nguyen Van Minh"``: a middle word that is also a shipped particle
+is claimed by the vocabulary layer before ``name_order`` is consulted
+at all. ``Van`` is the Dutch particle ``van``, so that name reads
+family ``Nguyen`` with ``Van Minh`` given under *both* family-first
+orders, and the choice between them makes no difference. `Words that
+are also ordinary names`_ covers dropping such a word from the
+vocabulary.
+
 East Asian defaults, and turning them off
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/v2/test_parser.py
+++ b/tests/v2/test_parser.py
@@ -147,6 +147,16 @@ def test_family_first_given_last_places_middle_between() -> None:
     assert (pn.family, pn.middle, pn.given) == ("Zeng", "Xiao", "Long")
 
 
+def test_ambiguous_particle_middle_defeats_both_family_first_orders() -> None:
+    # the vocabulary layer joins the ambiguous particle "van" forward
+    # before the positional layer runs, so a name whose middle word
+    # collides with it parses identically under either family-first
+    # order -- the caution in customize.rst rests on this
+    for order in (FAMILY_FIRST, FAMILY_FIRST_GIVEN_LAST):
+        pn = Parser(policy=Policy(name_order=order)).parse("Nguyen Van Minh")
+        assert (pn.family, pn.middle, pn.given) == ("Nguyen", "", "Van Minh")
+
+
 def test_multiple_unbalanced_delimiters_each_reported() -> None:
     # T4: the extract scan continues past the first unmatched opener;
     # each one is reported and treated as literal text


### PR DESCRIPTION
`FAMILY_FIRST_GIVEN_LAST` appeared in the docs only as reference-table entries — the API entry in `modules.rst`, one clause in the Policy field table, and a changelog bullet. Nothing showed what it does to a name. Since it is keyed to no script and has no locale pack, an explicit `Policy` is the only way to reach it, so the guide was the one place a reader could have found it.

Writing that up surfaced a problem in the example already there.

## The old example was inert

`customize.rst` demonstrated `FAMILY_FIRST` with **"Nguyen Van Minh"** — a Vietnamese name, while `modules.rst` names Vietnamese as the exemplar for `FAMILY_FIRST_GIVEN_LAST`. The two pages disagreed on the same name.

It also could not distinguish the two constants:

```
Nguyen Van Minh
  FAMILY_FIRST     family='Nguyen'  middle=''  given='Van Minh'
  FF_GIVEN_LAST    family='Nguyen'  middle=''  given='Van Minh'
```

`Van` collides with the Dutch particle `van` in `particles_ambiguous`, so the vocabulary layer joins it forward before the positional layer ever sees three tokens. The doctest passed, but it was exercising particle-joining rather than `name_order`, and reported the Vietnamese given name as "Van Minh" rather than "Minh".

Remove the collision and the constants separate:

```
Tran Quoc Toan
  FAMILY_FIRST     family='Tran'  middle='Toan'  given='Quoc'
  FF_GIVEN_LAST    family='Tran'  middle='Quoc'  given='Toan'   ← correct Vietnamese
```

## Changes

1. **`FAMILY_FIRST` moves to a Hungarian name** — what `modules.rst` already claims for the constant, and free of the collision. The middle field is now shown so the assignment order is visible.
2. **`FAMILY_FIRST_GIVEN_LAST` gets the Vietnamese name**, contrasted against `FAMILY_FIRST` on that single name, with a sentence of naming background first and a note that the order is keyed to no script (Latin carries none) and has no `vn` pack yet (#146).
3. **The collision is recorded** as prose plus a unit test rather than a second doctest block, per the lean-docs rule.

It extends the existing name-order section rather than adding a sibling — the constant only means anything in contrast with `FAMILY_FIRST`, and a separate section would duplicate the comma-precedence paragraph that follows.

## Verification

- `uv run pytest` — 3066 passed, 20 skipped, 11 xfailed
- `uv run sphinx-build -b doctest docs` — 223 tests, 0 failures (up from 218; +5 matches the new block's 5 statements)
- `uv run sphinx-build -b html -W --keep-going docs` — build succeeded, so the internal section link resolves
- The doctest harness was checked against a deliberately wrong expected value first, and reported the failure — the passing run is not inert

🤖 Generated with [Claude Code](https://claude.com/claude-code)