### PR TITLE
Sweep the regex-sync pins over every differential ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,9 +86,11 @@ uv run sphinx-build -b html docs dist/docs
 #    tools/differential/compare.py to the version just released, and create
 #    tools/differential/expected_since_<that version>.toml. Until both are done a
 #    bare compare.py measures against two minors back while reporting the
-#    previous one, and _allowlist_for hard-errors on the missing file. Land the
-#    regex-sync globbing (#333) FIRST, or the new ledger is born with the same
-#    unpinned hand copies of _SCRIPT_RANGES and the honorific vocabulary.
+#    previous one, and _allowlist_for hard-errors on the missing file. The new
+#    ledger's hand copies of _SCRIPT_RANGES and the honorific vocabulary are
+#    pinned automatically by tests/v2/test_regex_sync.py, which sweeps every
+#    expected_since_*.toml (#333) -- but add the file to _SPAN_BEARING_FLOORS
+#    there, or it fails as unrecorded (0 is correct if nothing CJK changed).
 ```
 
 Enable debug logging to see the parser's internal decisions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,11 +86,17 @@ uv run sphinx-build -b html docs dist/docs
 #    tools/differential/compare.py to the version just released, and create
 #    tools/differential/expected_since_<that version>.toml. Until both are done a
 #    bare compare.py measures against two minors back while reporting the
-#    previous one, and _allowlist_for hard-errors on the missing file. The new
-#    ledger's hand copies of _SCRIPT_RANGES and the honorific vocabulary are
-#    pinned automatically by tests/v2/test_regex_sync.py, which sweeps every
-#    expected_since_*.toml (#333) -- but add the file to _SPAN_BEARING_FLOORS
-#    there, or it fails as unrecorded (0 is correct if nothing CJK changed).
+#    previous one, and _allowlist_for hard-errors on the missing file.
+#    tests/v2/test_regex_sync.py sweeps every expected_since_*.toml (#333), so
+#    the new ledger's hand copies of _SCRIPT_RANGES and the honorific
+#    vocabulary are checked from the day the file lands -- but it enrolls
+#    itself in neither roster, and both failures are loud, not silent:
+#      - _SPAN_BEARING_RULES: add the filename, mapped to the set of issue
+#        tags whose rules carry a script-span class (empty set if none).
+#      - _HONORIFIC_SOURCES: if the ledger has a CJK honorific rule, add a
+#        substring of its issue (keyed that way, not by tag) mapped to the
+#        constant it copies. Its slug will be new by construction, so no
+#        existing key covers it, and it must match exactly one key.
 ```
 
 Enable debug logging to see the parser's internal decisions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,10 @@ uv run sphinx-build -b html docs dist/docs
 #        tags whose rules carry a script-span class (empty set if none).
 #      - _HONORIFIC_SOURCES: if the ledger has a CJK honorific rule, add a
 #        substring of its issue (keyed that way, not by tag) mapped to the
-#        constant it copies. Its slug will be new by construction, so no
-#        existing key covers it, and it must match exactly one key.
+#        constant it copies -- but only if no existing key already matches
+#        that issue. A retroactive ledger can repeat an older one's rule
+#        verbatim (fix(#271/#272/#298) is in both today), and every rule
+#        must match exactly one key.
 ```
 
 Enable debug logging to see the parser's internal decisions:

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -199,6 +199,19 @@ def _rules(ledger: Path) -> list[dict]:
     return tomllib.loads(ledger.read_text(encoding="utf-8"))["change"]
 
 
+def test_span_bearing_roster_names_exactly_the_ledgers_on_disk() -> None:
+    """The roster's per-ledger sweep asserts every ledger has an entry,
+    but it runs over _LEDGERS, so it can never visit an entry naming a
+    file that is gone. A deleted or renamed ledger would leave its key
+    behind indefinitely -- the same staleness the roster's tag-level
+    check exists to prevent, one level up."""
+    assert set(_SPAN_BEARING_RULES) == {ledger.name for ledger in _LEDGERS}, (
+        f"_SPAN_BEARING_RULES names ledgers that do not exist: "
+        f"{sorted(set(_SPAN_BEARING_RULES) - {L.name for L in _LEDGERS})}; "
+        f"and is missing: "
+        f"{sorted({L.name for L in _LEDGERS} - set(_SPAN_BEARING_RULES))}")
+
+
 _SPAN = re.compile(r"\\u([0-9A-Fa-f]{4})-\\u([0-9A-Fa-f]{4})")
 
 
@@ -228,13 +241,95 @@ def _unrecognized_class_content(name_regex: str) -> list[str]:
 
     So: a class that declares any span must declare NOTHING else.
     Classes carrying no spans (the delimiter sets) are a different
-    decision surface and are out of scope here.
+    decision surface and are out of scope here -- as is widening spelled
+    OUTSIDE the brackets, which _no_top_level_alternation covers.
+
+    Two known false positives, both deliberate: a single non-range
+    escape and a trailing literal "-" are legal regex and would be
+    rejected. Write them as a one-codepoint span instead. A class
+    metacharacter like \\s has no span spelling at all, so a rule
+    genuinely needing one has to move it out of the span-bearing class.
+
+    The bracket scan is a simple findall, not a regex parser: an escaped
+    "\\]" inside a class truncates the body early and a nested "[" reads
+    as content. Both surface as unrecognized content rather than as
+    silence, which is the safe direction, and no ledger rule uses either.
     """
     return [rest
             for body in re.findall(r"\[([^\]]*)\]", name_regex)
             if _SPAN.search(body)
             for rest in [_SPAN.sub("", body)]
             if rest]
+
+
+def _top_level_alternation(name_regex: str) -> bool:
+    """Whether the rule has a "|" at nesting depth 0.
+
+    The sibling of the hole above, three characters to the right of the
+    "]". Appending "|[A-Za-z]" to a span-bearing rule widens it exactly
+    as appending "a-z" inside the class would, and passes BOTH layers
+    that are supposed to stop that: the span equality sees an unchanged
+    class, and compare.validate_rules' sentinel probe clears it because
+    "Хосе Сантос" fails to match, breaking the matches-everything
+    conjunction. A CJK-scoped rule would then claim a Latin name's diff
+    as intended.
+
+    No ledger rule has one today, and a rule that genuinely needs an
+    alternation can wrap it in "(?:...)", so requiring depth-0 purity
+    costs nothing and closes the hatch.
+    """
+    depth = in_class = 0
+    i = 0
+    while i < len(name_regex):
+        char = name_regex[i]
+        if char == "\\":
+            i += 2
+            continue
+        if in_class:
+            in_class = char != "]"
+        elif char == "[":
+            in_class = 1
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif char == "|" and depth == 0:
+            return True
+        i += 1
+    return False
+
+
+#: Codepoints the script table classifies that a ledger rule may still
+#: spell literally inside a character class. The nakaguro separators
+#: sit in the katakana block by Unicode block assignment while
+#: functioning as punctuation, which is exactly why the delimiter rules
+#: write them as themselves alongside the corner brackets.
+_LITERAL_IN_CLASS_OK = frozenset("・･")
+
+_SPAN_TOKEN = re.compile(r"\\u[0-9A-Fa-f]{4}")
+
+
+def _literally_spelled_script_chars(name_regex: str) -> list[str]:
+    """Classified codepoints a class spells as themselves, not as spans.
+
+    This is the escape hatch every masking attack on the roster below
+    actually uses. Respell a rule's class in literal characters and the
+    regex means the same thing while the rule vanishes from discovery --
+    its hand copy is then unpinned, and _SPAN_BEARING_RULES cannot tell
+    a rule that LEFT from a rule that was never there, because a set of
+    names cannot see that two different rules answer to one name (the
+    1.4 ledger already has two rules tagged feat(#269)).
+
+    Naming rules could never fix that on its own. Closing the hatch can:
+    a classified codepoint written literally in a class is refused, so a
+    class covering script content has to stay in the notation discovery
+    reads.
+    """
+    return sorted({char
+                   for body in re.findall(r"\[([^\]]*)\]", name_regex)
+                   for char in _SPAN_TOKEN.sub("", body)
+                   if char not in _LITERAL_IN_CLASS_OK
+                   and _policy._script_matcher(*_policy._SCRIPT_RANGES)(char)})
 
 
 def _expected_bmp_spans() -> set[tuple[int, int]]:
@@ -394,6 +489,24 @@ def test_every_span_bearing_rule_matches_the_script_ranges(
             f"character class holding {extra!r} besides its spans. The "
             f"span equality above cannot see that, so it would widen the "
             f"rule unchecked -- write it as an escaped span or not at all")
+        assert not _top_level_alternation(regex), (
+            f"{ledger.name}: {rule['issue']!r} has a '|' at depth 0, so "
+            f"the whole rule is an alternation and the pinned class "
+            f"governs only one branch. Wrap it in '(?:...)'")
+    # Every rule, not just the discovered ones: this is what stops a
+    # class being respelled out of discovery in the first place, and it
+    # has to reach the rules that are NOT currently span-bearing to do
+    # that job.
+    for rule in _rules(ledger):
+        regex = rule.get("name_regex")
+        if not isinstance(regex, str):
+            continue
+        literal = _literally_spelled_script_chars(regex)
+        assert not literal, (
+            f"{ledger.name}: {rule['issue']!r} spells the classified "
+            f"codepoints {literal} literally inside a character class. "
+            f"Write them as \\uXXXX-\\uXXXX spans, or the rule drops out "
+            f"of the sweep above while meaning the same thing")
     # two rules sharing a tag would collapse into one set member and
     # read as a disappearance below, which is a confusing way to learn
     # that the naming scheme broke
@@ -515,15 +628,22 @@ _HONORIFIC_SOURCES: dict[str, set[str]] = {
 #: "(?:씨|님|先生)" would otherwise carry a hand copy this pin cannot
 #: see, which is the silent-unpinning this module exists to prevent.
 #:
-#: Shapes it still cannot read, and where each one lands (measured):
-#: an alternation with a nested group, or with a paren inside a
-#: character class, stops matching at all and surfaces through the
-#: STALE half of the roster check below. A "|" inside a character class
-#: is worse than unreadable -- it is MISread, since the member split is
-#: a plain str.split("|"): "[a|b]" becomes the two members "[a" and
-#: "b]", so the rule still matches its key and fails the declared-vs-
-#: expected equality instead. A single-member "group" is not an
-#: alternation at all and falls out silently, caught only by STALE.
+#: Shapes it still cannot read correctly. All of them fail, but by two
+#: different mechanisms, and the message you get depends on which
+#: (every row measured):
+#:
+#:   STALE half of the roster check -- the group stops matching, so the
+#:   rule's key goes unused:
+#:     a nested group whose inner members are UNclassified;
+#:     a paren inside a character class;
+#:     a single-member "group", which is not an alternation at all;
+#:     the named and inline-flag forms "(?P<n>a|b)" and "(?i:a|b)".
+#:
+#:   Declared-vs-expected equality -- the group still matches, but its
+#:   members are MISread, since the split is a plain str.split("|"):
+#:     "|" inside a character class: "[a|b]" yields "[a" and "b]";
+#:     a nested group whose inner members ARE classified: the inner
+#:     group is extracted and shows up as a member of the outer one.
 _ALTERNATION = re.compile(r"\((?:\?:|(?!\?))((?:[^()|]+\|)+[^()|]+)\)")
 
 

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -211,78 +211,65 @@ def _expected_bmp_spans() -> set[tuple[int, int]]:
             if span[1] <= 0xFFFF} | set(_SANCTIONED_EXTRAS)
 
 
-def test_differential_cjk_rule_matches_the_script_ranges() -> None:
-    """The CJK rule in tools/differential/expected_since_1.4.0.toml hand-
-    copies the script spans from _policy._SCRIPT_RANGES into a character
-    class. A TOML file cannot import the constant, so this is the one
-    copy with no possible alternative -- and the one whose divergence
-    is quietest, because the harness is run by hand rather than in CI.
+def test_script_ranges_membership_is_decided() -> None:
+    """The two guards that belong to the script TABLE rather than to any
+    one ledger's copy of it.
 
-    Both failure directions matter, which is why this compares sets
-    rather than checking coverage. A span MISSING from the class turns
-    an intended #271/#272 change into an UNEXPLAINED diff (a release
-    blocker for the wrong reason); a span that should not be there
-    silently classifies a real regression as intended, which is the
-    failure the whole harness exists to prevent.
-
-    Every table entry is in scope. The rule covered HAN and HANGUL
-    alone while the kana members existed only for classification, but
-    #272 gave HIRAGANA a default order entry and made the kana blocks
-    part of the same first/middle/last diff shape the rule explains,
-    so scoping it by issue no longer draws a real line. Comparing
-    against the whole table is also the stronger promise: a script
-    added to _SCRIPT_RANGES for ANY reason fails here until someone
-    decides, in writing, whether the rule should cover it.
+    Every table entry is in scope for the differential rules. The
+    canonical rule covered HAN and HANGUL alone while the kana members
+    existed only for classification, but #272 gave HIRAGANA a default
+    order entry and made the kana blocks part of the same
+    first/middle/last diff shape, so scoping by issue no longer draws a
+    real line. Comparing against the whole table is the stronger
+    promise: a script added to _SCRIPT_RANGES for ANY reason fails here
+    until someone decides, in writing, whether the rules should cover
+    it.
 
     Han's astral block is the single exception, out of scope on both
-    sides. The rule omits it deliberately -- no corpus name reaches
-    it, see the comment there -- so the comparison runs over the BMP
-    spans only.
+    sides -- no corpus name reaches it, see the comment there -- so the
+    span comparisons run over the BMP spans only.
 
-    The rule is also WIDER than the table by exactly one span, which
+    The rules are also WIDER than the table by exactly one span, which
     the equality has to know about or it would just fail forever. The
-    halfwidth middle dot U+FF65 changes parses without being
-    classified as anything: tokenize separates on it, so a halfwidth
-    transcription splits where 1.4 kept one token, while halfwidth
-    kana stays out of _SCRIPT_RANGES on purpose. U+00B7 -- the
-    context-sensitive 间隔号 (#298) -- also changes parses yet is
-    deliberately NOT an extra: its flank guard means every name it
-    can change matches the class through a flanking character
-    already, and a B7 span's only actual effect would be letting the
-    rule claim diffs on punt-volat Latin names (Gal·la), pre-excusing
-    a regression on exactly the guarded class. Naming the sanctioned
-    span here rather than relaxing the comparison to a subset check
-    is what keeps the pin honest in both directions: an unsanctioned
-    source of divergence still fails, and each sanctioned difference
-    has to be written down to exist.
+    halfwidth middle dot U+FF65 changes parses without being classified
+    as anything: tokenize separates on it, so a halfwidth transcription
+    splits where 1.4 kept one token, while halfwidth kana stays out of
+    _SCRIPT_RANGES on purpose. U+00B7 -- the context-sensitive 间隔号
+    (#298) -- also changes parses yet is deliberately NOT an extra: its
+    flank guard means every name it can change matches the class through
+    a flanking character already, and a B7 span's only actual effect
+    would be letting a rule claim diffs on punt-volat Latin names
+    (Gal·la), pre-excusing a regression on exactly the guarded class.
+    Naming the sanctioned span rather than relaxing the comparisons to a
+    subset check is what keeps the pins honest in both directions: an
+    unsanctioned source of divergence still fails, and each sanctioned
+    difference has to be written down to exist. The guard below is what
+    makes "sanctioned" mean something -- an extra that BECOMES
+    classified belongs in the table, not in the exception list.
+
+    There is deliberately no canonical-rule selector here any more. It
+    picked rules by the literal '#271'/'#272' substrings and asserted
+    uniqueness, which #332 broke: expected_since_2.0.0.toml has two such
+    rules. Its equality check was in any case fully subsumed by
+    test_every_span_bearing_rule_matches_the_script_ranges, since the
+    canonical rule is itself span-bearing. Splitting the two guarantees
+    is the point -- the sweep owns "every hand copy equals the table",
+    this test owns "the table did not change shape without a decision"
+    -- so a selector break can no longer take the decision gate out as
+    collateral. Rule authors are correspondingly free to put #271 or
+    #272 in a compound slug.
     """
-    toml_path = (Path(__file__).parents[2] / "tools" / "differential"
-                 / "expected_since_1.4.0.toml")
-    rules = tomllib.loads(toml_path.read_text())["change"]
-    matched = [r for r in rules
-               if "#271" in r["issue"] or "#272" in r["issue"]]
-    assert len(matched) == 1, (
-        f"expected exactly one CJK rule in {toml_path.name}, "
-        f"found {len(matched)}")
-    # A new table entry must force an explicit decision rather than
-    # quietly widening (or failing to widen) the rule above.
     assert set(_policy._SCRIPT_RANGES) == {
         Script.HAN, Script.HANGUL, Script.HIRAGANA, Script.KATAKANA}, (
-        "a Script joined _SCRIPT_RANGES: decide whether the "
-        f"differential rule in {toml_path.name} should cover it, then "
-        "update this assertion")
-    declared = _declared_spans(matched[0]["name_regex"])
-    # the extras must stay UNclassified, or they belong in the table
+        "a Script joined _SCRIPT_RANGES: decide whether the differential "
+        "rules in tools/differential/expected_since_*.toml should cover "
+        "it, then update this assertion")
     for xlo, xhi in _SANCTIONED_EXTRAS:
         assert not any(lo <= xhi and xlo <= hi
                        for spans in _policy._SCRIPT_RANGES.values()
                        for lo, hi in spans), (
             f"U+{xlo:04X}-U+{xhi:04X} is classified now; drop it "
             "from _SANCTIONED_EXTRAS")
-    expected = _expected_bmp_spans()
-    assert declared == expected, (
-        f"{toml_path.name}'s CJK name_regex declares {sorted(declared)}; "
-        f"_SCRIPT_RANGES' BMP spans are {sorted(expected)}")
 
 
 #: How many span-bearing rules each ledger is known to carry. A floor,

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -29,6 +29,7 @@ from nameparser._pipeline import _assign, _post_rules, _tokenize, _vocab
 from nameparser import _policy
 from nameparser._policy import Script
 from nameparser import _render
+from nameparser.config.suffixes import GLUED_HONORIFICS, SUFFIX_NOT_ACRONYMS
 
 
 def test_emoji_ranges_match_config() -> None:
@@ -395,31 +396,93 @@ def test_cjk_corpus_matches_the_case_table() -> None:
         "`uv run python tools/differential/build_cjk_corpus.py`")
 
 
-def test_differential_honorific_rule_matches_the_suffix_vocabulary() -> None:
-    """The fix(cjk-honorific-suffix) rule's alternation is a hand copy
-    of SUFFIX_NOT_ACRONYMS' CJK entries (#307) -- the toml cannot
-    import them. The expected set is DERIVED from the config by script
-    membership (a classified codepoint anywhere in the entry), so
-    adding a CJK honorific without widening the rule -- or widening
-    the rule with something the vocabulary does not ship -- fails
-    here. The span-bearing pins above skip this rule on purpose: its
-    trigger is the alternation, not a character class.
-    """
-    from nameparser.config.suffixes import SUFFIX_NOT_ACRONYMS
+#: Which vocabulary constant each ledger rule's alternation is a hand
+#: copy of. A roster rather than an inference: GLUED_HONORIFICS is a
+#: SUBSET of SUFFIX_NOT_ACRONYMS (asserted at the bottom of
+#: nameparser/config/suffixes.py), so "equals one of the two known sets"
+#: would let a spaced rule that silently narrowed to exactly the glued
+#: set pass by matching the other member -- a subset check wearing a
+#: disguise, and the subset direction is precisely the one that removal
+#: drift travels in.
+#:
+#: Keys are matched as substrings of a rule's `issue` and must select
+#: exactly one entry. The full issue lists are the keys, not a bare
+#: '#308': both 2.0 rules cite #308 while copying different constants.
+_HONORIFIC_SOURCES: dict[str, set[str]] = {
+    "cjk-honorific-suffix": SUFFIX_NOT_ACRONYMS,        # 1.4
+    "#307/#308/#320": SUFFIX_NOT_ACRONYMS,              # 2.0, spaced
+    "#308/#312/#319/#320": GLUED_HONORIFICS,            # 2.0, glued
+}
 
-    toml_path = (Path(__file__).parents[2] / "tools" / "differential"
-                 / "expected_since_1.4.0.toml")
-    rules = tomllib.loads(toml_path.read_text())["change"]
-    matched = [r for r in rules if "cjk-honorific-suffix" in r["issue"]]
-    assert len(matched) == 1
-    regex = matched[0]["name_regex"]
-    prefix = "(?:^| )(?:"
-    assert regex.startswith(prefix) and regex.endswith(")$"), (
-        "the honorific rule's shape changed; update this parser")
-    declared = set(regex[len(prefix):-2].split("|"))
+#: A (?:a|b|c) group with two or more alternatives and no nested
+#: parentheses. Verified to find exactly the three honorific
+#: alternations across both ledgers and nothing else: the rules' other
+#: groups are either lookarounds, which this does not match, or carry
+#: no script-classified member and are dropped by the filter below.
+_ALTERNATION = re.compile(r"\(\?:((?:[^()|]+\|)+[^()|]+)\)")
+
+
+def _cjk_alternations(name_regex: str) -> list[set[str]]:
+    """Every alternation in a rule with a script-classified member."""
     has_classified = _policy._script_matcher(*_policy._SCRIPT_RANGES)
-    expected = {entry for entry in SUFFIX_NOT_ACRONYMS
-                if has_classified(entry)}
-    assert declared == expected, (
-        f"rule declares {sorted(declared)}; the config's CJK suffix "
-        f"entries are {sorted(expected)}")
+    return [members
+            for body in _ALTERNATION.findall(name_regex)
+            for members in [set(body.split("|"))]
+            if any(has_classified(m) for m in members)]
+
+
+def test_differential_honorific_rules_match_their_vocabulary() -> None:
+    """The honorific rules' alternations are hand copies of the CJK
+    entries of SUFFIX_NOT_ACRONYMS (#307) and of GLUED_HONORIFICS
+    (#308) -- a toml cannot import them. Each expected set is DERIVED
+    from the config by script membership (a classified codepoint
+    anywhere in the entry), so adding a CJK honorific without widening
+    the rule, or widening a rule with something the vocabulary does not
+    ship, fails here.
+
+    Swept over every ledger and every alternation, because the three
+    copies are anchored three different ways -- a leading '(?:^| )' in
+    1.4, a character class and a lookbehind in 2.0 -- so the old
+    startswith/endswith parser could not read two of them. Discovery
+    plus a declared source is what replaces it.
+
+    The span-bearing pins skip these rules on purpose: their trigger is
+    the alternation, not a character class. Note GLUED_HONORIFICS had no
+    pinned copy anywhere in the tree before this.
+
+    Two completeness directions, both required. An alternation matching
+    no roster key fails as UNDECLARED, so a new rule's copy is pinned by
+    existing rather than by an author remembering to enroll it. A roster
+    key matching no rule fails as STALE, catching an entry left behind
+    after a rule was renamed or deleted.
+    """
+    has_classified = _policy._script_matcher(*_policy._SCRIPT_RANGES)
+    used: set[str] = set()
+    found = 0
+    for ledger in _LEDGERS:
+        for rule in _rules(ledger):
+            regex = rule.get("name_regex")
+            if not isinstance(regex, str):
+                continue
+            for declared in _cjk_alternations(regex):
+                keys = [k for k in _HONORIFIC_SOURCES if k in rule["issue"]]
+                assert len(keys) == 1, (
+                    f"{ledger.name}: rule {rule['issue']!r} carries a CJK "
+                    f"alternation matching {len(keys)} roster keys "
+                    f"({keys}); every such hand copy must name exactly "
+                    f"one source in _HONORIFIC_SOURCES")
+                used.add(keys[0])
+                found += 1
+                expected = {entry for entry in _HONORIFIC_SOURCES[keys[0]]
+                            if has_classified(entry)}
+                assert declared == expected, (
+                    f"{ledger.name}: {rule['issue']!r} declares "
+                    f"{sorted(declared)}; the config's CJK entries for "
+                    f"{keys[0]!r} are {sorted(expected)}")
+    assert found, (
+        "no CJK honorific alternation found in any ledger; this pin is "
+        "passing vacuously")
+    assert used == set(_HONORIFIC_SOURCES), (
+        f"_HONORIFIC_SOURCES keys matching no rule: "
+        f"{sorted(set(_HONORIFIC_SOURCES) - used)}. A renamed or deleted "
+        f"rule left its entry behind; drop it.")

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -12,9 +12,10 @@ convention), so this module is where the promise gets checked.
 Layering is the usual reason for a copy but not the only one, so this
 module's scope is the PROMISE rather than that one pair of packages:
 the comma-set pin below reads _pipeline._state instead of config, and
-the last three tests reach outside the package altogether -- two to a
-TOML file that could not import a Python constant if it wanted to,
-one to a generated corpus whose generator can, and must stay run.
+several tests reach outside the package altogether -- four to the
+differential ledgers, which could not import a Python constant if they
+wanted to, one to a generated corpus whose generator can, and must
+stay run.
 """
 import importlib.util
 import json
@@ -170,8 +171,10 @@ def test_comma_char_matches_the_pipeline_comma_set() -> None:
 # separates tokens without being classified (halfwidth kana stays out
 # of the table on purpose). U+00B7 is deliberately NOT here -- its
 # flank guard means every name it can change matches through a
-# classified flanking character already. Single-sourced: both span
-# pins below read this set.
+# classified flanking character already. Single-sourced: read by the
+# span sweep below, and by the membership guard that keeps "sanctioned"
+# meaning something -- an extra that becomes classified belongs in the
+# table, not in this list.
 _SANCTIONED_EXTRAS = frozenset({(0xFF65, 0xFF65)})
 
 _TOOLS = Path(__file__).parents[2] / "tools" / "differential"
@@ -184,9 +187,10 @@ _LEDGERS = sorted(_TOOLS.glob("expected_since_*.toml"))
 
 
 def test_ledger_glob_is_not_empty() -> None:
-    """A parametrize over an empty list generates zero tests and passes
-    vacuously -- the exact silence this module exists to break. The
-    swept pins cannot assert this for themselves, so it lives here."""
+    """A parametrize over an empty list generates a single silent SKIP
+    rather than a failure -- the exact silence this module exists to
+    break. The swept pins cannot assert this for themselves, since a
+    test that is never generated cannot complain, so it lives here."""
     assert _LEDGERS, f"no expected_since_*.toml under {_TOOLS}"
 
 
@@ -235,7 +239,14 @@ def _unrecognized_class_content(name_regex: str) -> list[str]:
 
 def _expected_bmp_spans() -> set[tuple[int, int]]:
     """What a full CJK character class in the toml must declare: the
-    table's BMP spans plus the sanctioned extras."""
+    table's BMP spans plus the sanctioned extras.
+
+    Han's astral block is the single table entry out of scope, on both
+    sides: the ledger rules omit it deliberately because no corpus name
+    reaches it (see the comment at the rule), so the comparisons run
+    over the BMP spans only rather than failing forever on a difference
+    everyone agreed to.
+    """
     return {span
             for spans in _policy._SCRIPT_RANGES.values()
             for span in spans
@@ -256,27 +267,12 @@ def test_script_ranges_membership_is_decided() -> None:
     until someone decides, in writing, whether the rules should cover
     it.
 
-    Han's astral block is the single exception, out of scope on both
-    sides -- no corpus name reaches it, see the comment there -- so the
-    span comparisons run over the BMP spans only.
-
-    The rules are also WIDER than the table by exactly one span, which
-    the equality has to know about or it would just fail forever. The
-    halfwidth middle dot U+FF65 changes parses without being classified
-    as anything: tokenize separates on it, so a halfwidth transcription
-    splits where 1.4 kept one token, while halfwidth kana stays out of
-    _SCRIPT_RANGES on purpose. U+00B7 -- the context-sensitive 间隔号
-    (#298) -- also changes parses yet is deliberately NOT an extra: its
-    flank guard means every name it can change matches the class through
-    a flanking character already, and a B7 span's only actual effect
-    would be letting a rule claim diffs on punt-volat Latin names
-    (Gal·la), pre-excusing a regression on exactly the guarded class.
-    Naming the sanctioned span rather than relaxing the comparisons to a
-    subset check is what keeps the pins honest in both directions: an
-    unsanctioned source of divergence still fails, and each sanctioned
-    difference has to be written down to exist. The guard below is what
-    makes "sanctioned" mean something -- an extra that BECOMES
-    classified belongs in the table, not in the exception list.
+    The second assert is what makes _SANCTIONED_EXTRAS mean something.
+    That set is the ledgers' licence to be WIDER than the table -- see
+    its definition above for why U+FF65 is in it and U+00B7 is not --
+    and a licence nobody audits is just a hole. An extra that becomes
+    classified belongs in the table, not in the exception list, and
+    fails here until it moves.
 
     There is deliberately no canonical-rule selector here any more. It
     picked rules by the literal '#271'/'#272' substrings and asserted
@@ -425,10 +421,18 @@ _NICKNAME_DELIMITERS = "[「」『』・･]"
 def test_nickname_delimiter_sets_are_deliberate() -> None:
     """Swept rather than pinned to one file and one rule. The 1.4 ledger
     has exactly one cjk-delimited-nickname rule and the 2.0 ledger has
-    none, so neither a per-file `== 1` nor a global one is true; what is
-    true is that EVERY such rule must carry the sanctioned trigger set,
-    and that at least one must exist somewhere or this is checking
-    nothing."""
+    none, so a per-file `== 1` is already false and a global one holds
+    only by accident of there being a single rule today. What is
+    actually invariant is that EVERY such rule carries the sanctioned
+    trigger set, and that at least one exists somewhere or this is
+    checking nothing.
+
+    Note the scope this does NOT have: it is a decision surface, not a
+    sync pin. _NICKNAME_DELIMITERS is a literal rather than derived
+    from Policy.nickname_delimiters because the two are not the same
+    set -- the class also carries the nakaguro separators, which
+    delimit nothing. Removing a real delimiter pair from the config
+    fails the behavior tests in tests/v2/pipeline/, not here."""
     found = []
     for ledger in _LEDGERS:
         for rule in _rules(ledger):

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -216,8 +216,8 @@ def _unrecognized_class_content(name_regex: str) -> list[str]:
     escaped span. Anything appended in another notation -- a literal
     range, a bare character, a leading "^" negating the whole class --
     is invisible to it and rides along unchecked. That is not
-    hypothetical: this file's own convention mixes both spellings (see
-    the interpunct note in expected_since_2.0.0.toml), and the ledgers'
+    hypothetical: the ledgers' own convention mixes both spellings (see
+    the interpunct note in expected_since_2.0.0.toml), and their
     non-span classes are written literally.
 
     The consequence is worst in the widening direction the equality is
@@ -243,9 +243,10 @@ def _expected_bmp_spans() -> set[tuple[int, int]]:
 
     Han's astral block is the single table entry out of scope, on both
     sides: the ledger rules omit it deliberately because no corpus name
-    reaches it (see the comment at the rule), so the comparisons run
-    over the BMP spans only rather than failing forever on a difference
-    everyone agreed to.
+    reaches it -- see the comment on the canonical rule in
+    expected_since_1.4.0.toml, which is the only place that reasoning is
+    written down -- so the comparisons run over the BMP spans only
+    rather than failing forever on a difference everyone agreed to.
     """
     return {span
             for spans in _policy._SCRIPT_RANGES.values()
@@ -428,21 +429,30 @@ def test_nickname_delimiter_sets_are_deliberate() -> None:
     checking nothing.
 
     Note the scope this does NOT have: it is a decision surface, not a
-    sync pin. _NICKNAME_DELIMITERS is a literal rather than derived
-    from Policy.nickname_delimiters because the two are not the same
-    set -- the class also carries the nakaguro separators, which
-    delimit nothing. Removing a real delimiter pair from the config
-    fails the behavior tests in tests/v2/pipeline/, not here."""
+    sync pin. _NICKNAME_DELIMITERS is a literal because the rule's class
+    is not Policy.nickname_delimiters and is not meant to be -- it is
+    the two CJK corner-bracket pairs, plus the nakaguro separators,
+    which delimit nothing, and minus the nine other pairs the config
+    ships. Deriving it would mean deciding all of that in code rather
+    than writing it down.
+
+    So a delimiter pair removed from the config does not fail here; it
+    fails tests/v2/test_cases.py, on the cjk_white_corner_bracket_
+    nickname row (measured -- tests/v2/pipeline/ stays green, which is
+    why the pointer is worth being exact about)."""
     found = []
     for ledger in _LEDGERS:
         for rule in _rules(ledger):
             if "cjk-delimited-nickname" not in rule["issue"]:
                 continue
             found.append(f"{ledger.name}: {rule['issue']}")
+            # .get rather than [] on purpose: a rule that dropped its
+            # name_regex outright should land on the assertion below,
+            # not raise KeyError out of the sweep
             assert _NICKNAME_DELIMITERS in rule.get("name_regex", ""), (
                 f"{ledger.name}: the compound rule's delimiter set "
-                f"changed; decide deliberately, then update "
-                f"_NICKNAME_DELIMITERS")
+                f"changed, or the rule lost its name_regex; decide "
+                f"deliberately, then update _NICKNAME_DELIMITERS")
     assert found, (
         "no cjk-delimited-nickname rule in any ledger; this check is "
         "passing vacuously")
@@ -505,11 +515,15 @@ _HONORIFIC_SOURCES: dict[str, set[str]] = {
 #: "(?:씨|님|先生)" would otherwise carry a hand copy this pin cannot
 #: see, which is the silent-unpinning this module exists to prevent.
 #:
-#: Still unreadable to it, by construction: an alternation with a
-#: nested group, one with a "|" or paren inside a character class, and
-#: a single-member "group". The first two surface through the STALE
-#: half of the roster check below -- the rule stops matching its key --
-#: rather than passing quietly.
+#: Shapes it still cannot read, and where each one lands (measured):
+#: an alternation with a nested group, or with a paren inside a
+#: character class, stops matching at all and surfaces through the
+#: STALE half of the roster check below. A "|" inside a character class
+#: is worse than unreadable -- it is MISread, since the member split is
+#: a plain str.split("|"): "[a|b]" becomes the two members "[a" and
+#: "b]", so the rule still matches its key and fails the declared-vs-
+#: expected equality instead. A single-member "group" is not an
+#: alternation at all and falls out silently, caught only by STALE.
 _ALTERNATION = re.compile(r"\((?:\?:|(?!\?))((?:[^()|]+\|)+[^()|]+)\)")
 
 
@@ -576,7 +590,8 @@ def test_differential_honorific_rules_match_their_vocabulary() -> None:
     assert used == set(_HONORIFIC_SOURCES), (
         f"_HONORIFIC_SOURCES keys matching no rule: "
         f"{sorted(set(_HONORIFIC_SOURCES) - used)}. Either a renamed or "
-        f"deleted rule left its entry behind -- drop it -- or that rule's "
-        f"alternation is no longer parseable by _ALTERNATION (a nested "
-        f"group, or a '|' inside a character class), which is how a "
-        f"still-present hand copy silently leaves this pin.")
+        f"deleted rule left its entry behind -- drop it -- or that "
+        f"rule's alternation stopped matching _ALTERNATION (a nested "
+        f"group, a paren inside a character class, or a lone member), "
+        f"which is how a still-present hand copy silently leaves this "
+        f"pin.")

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -173,6 +173,26 @@ def test_comma_char_matches_the_pipeline_comma_set() -> None:
 # pins below read this set.
 _SANCTIONED_EXTRAS = frozenset({(0xFF65, 0xFF65)})
 
+_TOOLS = Path(__file__).parents[2] / "tools" / "differential"
+
+#: Every baseline's ledger, swept rather than named. #332 added a second
+#: file whose four hand copies went unchecked because the pins below
+#: named the 1.4 one by filename, and the count grows by one per
+#: release -- see AGENTS.md's release step 8.
+_LEDGERS = sorted(_TOOLS.glob("expected_since_*.toml"))
+
+
+def test_ledger_glob_is_not_empty() -> None:
+    """A parametrize over an empty list generates zero tests and passes
+    vacuously -- the exact silence this module exists to break. The
+    swept pins cannot assert this for themselves, so it lives here."""
+    assert _LEDGERS, f"no expected_since_*.toml under {_TOOLS}"
+
+
+def _rules(ledger: Path) -> list[dict]:
+    """The [[change]] table of one ledger."""
+    return tomllib.loads(ledger.read_text(encoding="utf-8"))["change"]
+
 
 def _declared_spans(name_regex: str) -> set[tuple[int, int]]:
     """The \\uXXXX-\\uXXXX span pairs a rule's character class declares."""

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -273,19 +273,45 @@ def test_script_ranges_membership_is_decided() -> None:
             "from _SANCTIONED_EXTRAS")
 
 
-#: How many span-bearing rules each ledger is known to carry. A floor,
-#: not an equality: a NEW span-bearing rule is pinned by discovery the
-#: moment it exists, so forcing a bump here would be churn. The number
-#: exists to catch a copy that fell OUT of discovery's reach, and it is
-#: per-file so the failure names the ledger that lost one.
+#: Which rules each ledger is known to carry a script-span copy in,
+#: named by the leading fix(...)/feat(...) tag of their `issue`.
+#:
+#: Declared rather than counted. A count is identity-free, so one copy
+#: could leave discovery -- rewritten as literal characters, say -- while
+#: an unrelated span-bearing rule was added, and the total would hold
+#: steady while a hand copy went unpinned (measured). Naming them also
+#: buys the staleness direction the count never had, and that this
+#: module's other two rosters already have: a tag here that matches no
+#: rule fails, so a renamed or deleted rule cannot leave its entry
+#: behind.
 #:
 #: Membership is the forcing function: a new baseline's ledger fails as
-#: unrecorded until someone writes its count down. Recording 0 is fine
+#: unrecorded until someone writes its rules down. An empty set is fine
 #: and correct for a release that changed nothing CJK.
-_SPAN_BEARING_FLOORS = {
-    "expected_since_1.4.0.toml": 4,   # canonical + three compounds
-    "expected_since_2.0.0.toml": 2,   # canonical + the #298 lookahead
+_SPAN_BEARING_RULES: dict[str, frozenset[str]] = {
+    "expected_since_1.4.0.toml": frozenset({
+        "fix(#271/#272/#298)",              # the canonical class
+        "fix(cjk-delimited-nickname)",      # the three compounds, whose
+        "fix(cjk-fullwidth-paren-nickname)",  # lookaheads each carry
+        "fix(cjk-comma-compound)",          # their own copy
+    }),
+    "expected_since_2.0.0.toml": frozenset({
+        "fix(#271/#272/#298)",              # the canonical class
+        "fix(#298)",                        # the 间隔号 lookahead
+    }),
 }
+
+#: The leading `fix(...)`/`feat(...)` tag of a rule's `issue`, which is
+#: what _SPAN_BEARING_RULES names rules by. Unique within each ledger
+#: among span-bearing rules (asserted below), and stable across the
+#: prose that follows it.
+_ISSUE_TAG = re.compile(r"^[a-z]+\([^)]*\)")
+
+
+def _tag(issue: str) -> str:
+    match = _ISSUE_TAG.match(issue)
+    assert match, f"rule issue does not open with a fix(...) tag: {issue!r}"
+    return match.group(0)
 
 
 @pytest.mark.parametrize("ledger", _LEDGERS, ids=lambda p: p.name)
@@ -310,18 +336,20 @@ def test_every_span_bearing_rule_matches_the_script_ranges(
     The compound rules' require-a-classified-codepoint lookaheads exist
     so their trigger sets alone (delimiters; a comma) cannot claim a
     Latin name's regression -- and each such lookahead is a copy nothing
-    else checks. Discovery replaces a hand-maintained slug roster: a new
-    compound rule's copy is pinned by existing here, not by an author
-    remembering to enroll it. Rules whose spans touch OTHER scripts
-    (Cyrillic, say) are out of scope and skipped by the intersection
-    test.
+    else checks. Discovery, not enrollment, is what subjects a rule to
+    the equality above: a new compound rule's copy is checked because it
+    exists, not because an author remembered it. _SPAN_BEARING_RULES
+    then holds discovery itself to account, since a copy rewritten in a
+    notation discovery cannot see would otherwise just vanish from the
+    sweep. Rules whose spans touch OTHER scripts (Cyrillic, say) are out
+    of scope and skipped by the intersection test.
     """
-    assert ledger.name in _SPAN_BEARING_FLOORS, (
-        f"{ledger.name} is a new ledger with no recorded span-bearing "
-        f"count; add it to _SPAN_BEARING_FLOORS (0 is a legal answer "
-        f"for a release that changed nothing CJK)")
+    assert ledger.name in _SPAN_BEARING_RULES, (
+        f"{ledger.name} is a new ledger whose span-bearing rules are not "
+        f"recorded; add it to _SPAN_BEARING_RULES (an empty set is a "
+        f"legal answer for a release that changed nothing CJK)")
     table_spans = _expected_bmp_spans()
-    checked = []
+    tags = []
     for rule in _rules(ledger):
         regex = rule.get("name_regex")
         if not isinstance(regex, str):
@@ -329,14 +357,23 @@ def test_every_span_bearing_rule_matches_the_script_ranges(
         declared = _declared_spans(regex)
         if not declared & table_spans:
             continue
-        checked.append(rule["issue"])
+        tags.append(_tag(rule["issue"]))
         assert declared == table_spans, (
             f"{ledger.name}: {rule['issue']!r} declares "
             f"{sorted(declared)}; expected {sorted(table_spans)}")
-    assert len(checked) >= _SPAN_BEARING_FLOORS[ledger.name], (
-        f"{ledger.name} carries {len(checked)} span-bearing rules, "
-        f"below its recorded {_SPAN_BEARING_FLOORS[ledger.name]}: a hand "
-        f"copy fell out of discovery's reach. {checked}")
+    # two rules sharing a tag would collapse into one set member and
+    # read as a disappearance below, which is a confusing way to learn
+    # that the naming scheme broke
+    assert len(tags) == len(set(tags)), (
+        f"{ledger.name}: two span-bearing rules share an issue tag "
+        f"({sorted(tags)}); _SPAN_BEARING_RULES cannot name them apart")
+    found = set(tags)
+    assert found == _SPAN_BEARING_RULES[ledger.name], (
+        f"{ledger.name}'s span-bearing rules are not the recorded set. "
+        f"Left discovery (a hand copy is now unpinned): "
+        f"{sorted(_SPAN_BEARING_RULES[ledger.name] - found)}. "
+        f"Newly discovered (pinned now, but record it): "
+        f"{sorted(found - _SPAN_BEARING_RULES[ledger.name])}")
 
 
 #: The delimiter compound's trigger set is its own decision surface,

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -285,30 +285,56 @@ def test_differential_cjk_rule_matches_the_script_ranges() -> None:
         f"_SCRIPT_RANGES' BMP spans are {sorted(expected)}")
 
 
-def test_every_span_bearing_rule_matches_the_script_ranges() -> None:
-    """Auto-discovered pin for every FURTHER hand copy of the script
-    spans in the toml: any rule whose character class declares spans
+#: How many span-bearing rules each ledger is known to carry. A floor,
+#: not an equality: a NEW span-bearing rule is pinned by discovery the
+#: moment it exists, so forcing a bump here would be churn. The number
+#: exists to catch a copy that fell OUT of discovery's reach, and it is
+#: per-file so the failure names the ledger that lost one.
+#:
+#: Membership is the forcing function: a new baseline's ledger fails as
+#: unrecorded until someone writes its count down. Recording 0 is fine
+#: and correct for a release that changed nothing CJK.
+_SPAN_BEARING_FLOORS = {
+    "expected_since_1.4.0.toml": 4,   # canonical + three compounds
+    "expected_since_2.0.0.toml": 2,   # canonical + the #298 lookahead
+}
+
+
+@pytest.mark.parametrize("ledger", _LEDGERS, ids=lambda p: p.name)
+def test_every_span_bearing_rule_matches_the_script_ranges(
+        ledger: Path) -> None:
+    """Auto-discovered pin for every hand copy of the script spans in
+    every ledger: any rule whose character class declares spans
     intersecting _SCRIPT_RANGES must declare the whole expected class
-    (table BMP spans + sanctioned extras). The compound rules'
-    require-a-classified-codepoint lookaheads exist so their trigger
-    sets alone (delimiters; a comma) cannot claim a Latin name's
-    regression -- and each such lookahead is a copy nothing else
-    checks. Discovery replaces a hand-maintained slug roster: a new
+    (table BMP spans + sanctioned extras).
+
+    A TOML file cannot import _policy._SCRIPT_RANGES, so these are the
+    copies with no possible alternative -- and the ones whose divergence
+    is quietest, because the harness is run by hand rather than in CI.
+
+    Both failure directions matter, which is why this compares sets
+    rather than checking coverage. A span MISSING from a class turns an
+    intended change into an UNEXPLAINED diff (a release blocker for the
+    wrong reason); a span that should not be there silently classifies a
+    real regression as intended, which is the failure the whole harness
+    exists to prevent.
+
+    The compound rules' require-a-classified-codepoint lookaheads exist
+    so their trigger sets alone (delimiters; a comma) cannot claim a
+    Latin name's regression -- and each such lookahead is a copy nothing
+    else checks. Discovery replaces a hand-maintained slug roster: a new
     compound rule's copy is pinned by existing here, not by an author
     remembering to enroll it. Rules whose spans touch OTHER scripts
     (Cyrillic, say) are out of scope and skipped by the intersection
     test.
-
-    Selection note for future rule authors: the canonical-rule pin
-    above selects by the literal '#271'/'#272' substrings and asserts
-    uniqueness -- compound slugs must avoid them.
     """
-    toml_path = (Path(__file__).parents[2] / "tools" / "differential"
-                 / "expected_since_1.4.0.toml")
-    rules = tomllib.loads(toml_path.read_text())["change"]
+    assert ledger.name in _SPAN_BEARING_FLOORS, (
+        f"{ledger.name} is a new ledger with no recorded span-bearing "
+        f"count; add it to _SPAN_BEARING_FLOORS (0 is a legal answer "
+        f"for a release that changed nothing CJK)")
     table_spans = _expected_bmp_spans()
     checked = []
-    for rule in rules:
+    for rule in _rules(ledger):
         regex = rule.get("name_regex")
         if not isinstance(regex, str):
             continue
@@ -317,18 +343,12 @@ def test_every_span_bearing_rule_matches_the_script_ranges() -> None:
             continue
         checked.append(rule["issue"])
         assert declared == table_spans, (
-            f"{rule['issue']!r} declares {sorted(declared)}; expected "
-            f"{sorted(table_spans)}")
-    # the canonical rule plus both compound rules, today -- if this
-    # count drops, a hand copy fell out of discovery's reach
-    assert len(checked) >= 3, checked
-    # the delimiter compound's trigger set is its own decision surface
-    nickname = [r for r in rules
-                if "cjk-delimited-nickname" in r["issue"]]
-    assert len(nickname) == 1
-    assert "[\u300C\u300D\u300E\u300F\u30FB\uFF65]" in nickname[0][
-        "name_regex"] or "[「」『』・･]" in nickname[0]["name_regex"], (
-        "the compound rule's delimiter set changed; decide deliberately")
+            f"{ledger.name}: {rule['issue']!r} declares "
+            f"{sorted(declared)}; expected {sorted(table_spans)}")
+    assert len(checked) >= _SPAN_BEARING_FLOORS[ledger.name], (
+        f"{ledger.name} carries {len(checked)} span-bearing rules, "
+        f"below its recorded {_SPAN_BEARING_FLOORS[ledger.name]}: a hand "
+        f"copy fell out of discovery's reach. {checked}")
 
 
 def test_cjk_corpus_matches_the_case_table() -> None:

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -338,6 +338,38 @@ def test_every_span_bearing_rule_matches_the_script_ranges(
         f"copy fell out of discovery's reach. {checked}")
 
 
+#: The delimiter compound's trigger set is its own decision surface,
+#: separate from the script spans: these are the characters whose mere
+#: presence lets the rule claim a diff. Written once here rather than
+#: inline: the check this replaces tested the regex against this set
+#: spelled as unicode escapes OR against it spelled as the characters
+#: themselves, which in a non-raw literal are the same str -- an `or`
+#: whose two operands could never disagree. One spelling, named once.
+_NICKNAME_DELIMITERS = "[「」『』・･]"
+
+
+def test_nickname_delimiter_sets_are_deliberate() -> None:
+    """Swept rather than pinned to one file and one rule. The 1.4 ledger
+    has exactly one cjk-delimited-nickname rule and the 2.0 ledger has
+    none, so neither a per-file `== 1` nor a global one is true; what is
+    true is that EVERY such rule must carry the sanctioned trigger set,
+    and that at least one must exist somewhere or this is checking
+    nothing."""
+    found = []
+    for ledger in _LEDGERS:
+        for rule in _rules(ledger):
+            if "cjk-delimited-nickname" not in rule["issue"]:
+                continue
+            found.append(f"{ledger.name}: {rule['issue']}")
+            assert _NICKNAME_DELIMITERS in rule["name_regex"], (
+                f"{ledger.name}: the compound rule's delimiter set "
+                f"changed; decide deliberately, then update "
+                f"_NICKNAME_DELIMITERS")
+    assert found, (
+        "no cjk-delimited-nickname rule in any ledger; this check is "
+        "passing vacuously")
+
+
 def test_cjk_corpus_matches_the_case_table() -> None:
     """corpus_cjk.jsonl is GENERATED, not curated (#295): every
     distinct case-table text bearing a codepoint the script table

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -431,8 +431,19 @@ _ISSUE_TAG = re.compile(r"^[a-z]+\([^)]*\)")
 
 
 def _tag(issue: str) -> str:
+    """The leading tag, required only of rules the roster has to name.
+
+    Nothing obliges a ledger rule to carry a tag in general, and one in
+    the 1.4 file does not ("ambiguous-surname-acronym data change:
+    ..."). That is fine while it declares no script span. If such a rule
+    ever gains one it lands here, and the fix is to give it a tag rather
+    than to loosen the roster.
+    """
     match = _ISSUE_TAG.match(issue)
-    assert match, f"rule issue does not open with a fix(...) tag: {issue!r}"
+    assert match, (
+        f"a span-bearing rule's issue must open with a fix(...) or "
+        f"feat(...) tag so _SPAN_BEARING_RULES can name it; this one "
+        f"does not: {issue!r}")
     return match.group(0)
 
 

--- a/tests/v2/test_regex_sync.py
+++ b/tests/v2/test_regex_sync.py
@@ -195,12 +195,42 @@ def _rules(ledger: Path) -> list[dict]:
     return tomllib.loads(ledger.read_text(encoding="utf-8"))["change"]
 
 
+_SPAN = re.compile(r"\\u([0-9A-Fa-f]{4})-\\u([0-9A-Fa-f]{4})")
+
+
 def _declared_spans(name_regex: str) -> set[tuple[int, int]]:
     """The \\uXXXX-\\uXXXX span pairs a rule's character class declares."""
-    return {
-        (int(lo, 16), int(hi, 16))
-        for lo, hi in re.findall(r"\\u([0-9A-Fa-f]{4})-\\u([0-9A-Fa-f]{4})",
-                                 name_regex)}
+    return {(int(lo, 16), int(hi, 16))
+            for lo, hi in _SPAN.findall(name_regex)}
+
+
+def _unrecognized_class_content(name_regex: str) -> list[str]:
+    """Whatever a span-declaring character class holds BESIDES spans.
+
+    _declared_spans reads one notation and is blind to every other, so
+    set equality against the table only pins what is written as an
+    escaped span. Anything appended in another notation -- a literal
+    range, a bare character, a leading "^" negating the whole class --
+    is invisible to it and rides along unchecked. That is not
+    hypothetical: this file's own convention mixes both spellings (see
+    the interpunct note in expected_since_2.0.0.toml), and the ledgers'
+    non-span classes are written literally.
+
+    The consequence is worst in the widening direction the equality is
+    supposed to cover. Appending "a-z" to a pinned CJK class passes both
+    that equality and compare.validate_rules' sentinel probe, and lets
+    the rule claim every Latin diff in the corpus as intended -- exactly
+    the regression-absorbing failure the harness exists to prevent.
+
+    So: a class that declares any span must declare NOTHING else.
+    Classes carrying no spans (the delimiter sets) are a different
+    decision surface and are out of scope here.
+    """
+    return [rest
+            for body in re.findall(r"\[([^\]]*)\]", name_regex)
+            if _SPAN.search(body)
+            for rest in [_SPAN.sub("", body)]
+            if rest]
 
 
 def _expected_bmp_spans() -> set[tuple[int, int]]:
@@ -361,6 +391,12 @@ def test_every_span_bearing_rule_matches_the_script_ranges(
         assert declared == table_spans, (
             f"{ledger.name}: {rule['issue']!r} declares "
             f"{sorted(declared)}; expected {sorted(table_spans)}")
+        extra = _unrecognized_class_content(regex)
+        assert not extra, (
+            f"{ledger.name}: {rule['issue']!r} has a span-declaring "
+            f"character class holding {extra!r} besides its spans. The "
+            f"span equality above cannot see that, so it would widen the "
+            f"rule unchecked -- write it as an escaped span or not at all")
     # two rules sharing a tag would collapse into one set member and
     # read as a disappearance below, which is a confusing way to learn
     # that the naming scheme broke
@@ -399,7 +435,7 @@ def test_nickname_delimiter_sets_are_deliberate() -> None:
             if "cjk-delimited-nickname" not in rule["issue"]:
                 continue
             found.append(f"{ledger.name}: {rule['issue']}")
-            assert _NICKNAME_DELIMITERS in rule["name_regex"], (
+            assert _NICKNAME_DELIMITERS in rule.get("name_regex", ""), (
                 f"{ledger.name}: the compound rule's delimiter set "
                 f"changed; decide deliberately, then update "
                 f"_NICKNAME_DELIMITERS")
@@ -451,12 +487,26 @@ _HONORIFIC_SOURCES: dict[str, set[str]] = {
     "#308/#312/#319/#320": GLUED_HONORIFICS,            # 2.0, glued
 }
 
-#: A (?:a|b|c) group with two or more alternatives and no nested
-#: parentheses. Verified to find exactly the three honorific
-#: alternations across both ledgers and nothing else: the rules' other
-#: groups are either lookarounds, which this does not match, or carry
-#: no script-classified member and are dropped by the filter below.
-_ALTERNATION = re.compile(r"\(\?:((?:[^()|]+\|)+[^()|]+)\)")
+#: An alternation group with two or more members and no nested
+#: parentheses, capturing or not. Together with the classified-member
+#: filter in _cjk_alternations it selects exactly the three honorific
+#: alternations across both ledgers; on its own it also matches
+#: "(?:^| )" from the 1.4 rule and the two Latin maiden/acronym
+#: alternations, all of which the filter drops.
+#:
+#: The "(?:" alternative is spelled out and the plain "(" is guarded by
+#: (?!\?) so that lookarounds -- "(?=$|[ ,])", "(?<=[^\s,])" -- do not
+#: parse as alternations of their own syntax. Matching plain capturing
+#: groups matters: a rule written "(씨|님|先生)" instead of
+#: "(?:씨|님|先生)" would otherwise carry a hand copy this pin cannot
+#: see, which is the silent-unpinning this module exists to prevent.
+#:
+#: Still unreadable to it, by construction: an alternation with a
+#: nested group, one with a "|" or paren inside a character class, and
+#: a single-member "group". The first two surface through the STALE
+#: half of the roster check below -- the rule stops matching its key --
+#: rather than passing quietly.
+_ALTERNATION = re.compile(r"\((?:\?:|(?!\?))((?:[^()|]+\|)+[^()|]+)\)")
 
 
 def _cjk_alternations(name_regex: str) -> list[set[str]]:
@@ -521,5 +571,8 @@ def test_differential_honorific_rules_match_their_vocabulary() -> None:
         "passing vacuously")
     assert used == set(_HONORIFIC_SOURCES), (
         f"_HONORIFIC_SOURCES keys matching no rule: "
-        f"{sorted(set(_HONORIFIC_SOURCES) - used)}. A renamed or deleted "
-        f"rule left its entry behind; drop it.")
+        f"{sorted(set(_HONORIFIC_SOURCES) - used)}. Either a renamed or "
+        f"deleted rule left its entry behind -- drop it -- or that rule's "
+        f"alternation is no longer parseable by _ALTERNATION (a nested "
+        f"group, or a '|' inside a character class), which is how a "
+        f"still-present hand copy silently leaves this pin.")

--- a/tools/differential/expected_since_1.4.0.toml
+++ b/tools/differential/expected_since_1.4.0.toml
@@ -209,9 +209,10 @@ issue = "fix(cjk-delimited-nickname) delimiter recognition compounds with the CJ
 # overlaps the CJK rule above and the delimiter rule below; within
 # the name_regex tier file order decides which label a diff reports
 # under, so it sits after the tighter single-change rules on purpose.
-# The issue slug deliberately avoids the literal #271/#272 strings --
-# test_regex_sync's differential pin selects the canonical CJK rule
-# by those substrings and asserts it is unique.
+# The slug is free-form. It used to avoid the literal #271/#272
+# strings, because a pin selected the canonical CJK rule by those
+# substrings and asserted uniqueness; that pin is gone (#333) and the
+# span sweep finds rules by their character class instead.
 name_regex = "(?s)(?=.*[「」『』・･])(?=.*[\\u3005-\\u3006\\u3040-\\u309F\\u30A0-\\u30FF\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF\\uAC00-\\uD7A3\\uFF65-\\uFF65])"
 fields = ["given", "family", "nickname"]
 
@@ -243,9 +244,9 @@ issue = "fix(cjk-fullwidth-paren-nickname) fullwidth-parenthesis recognition com
 # span, so a Latin name can carry it ('John （Jack） Kennedy') and the
 # delimiter alone would let this rule absorb a first/last regression on
 # one. The span class is the same hand copy of _SCRIPT_RANGES the rules
-# above carry, pinned by the same auto-discovering test. The slug
-# avoids the literal #271/#272 substrings the canonical-rule pin
-# selects by.
+# above carry, pinned by the same auto-discovering test. The slug is
+# free-form; the #271/#272 substrings it avoids were a constraint of a
+# selector retired in #333.
 name_regex = "(?s)(?=.*[（）])(?=.*[\\u3005-\\u3006\\u3040-\\u309F\\u30A0-\\u30FF\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF\\uAC00-\\uD7A3\\uFF65-\\uFF65])"
 fields = ["given", "middle", "family", "nickname"]
 
@@ -263,8 +264,9 @@ issue = "fix(cjk-comma-compound) comma routing compounds with the CJK order flip
 # 'Smith, Jr.' in the corpus, and the classified-codepoint lookahead
 # confines the rule to names the CJK behaviors can actually reach.
 # The class is the same hand copy of _SCRIPT_RANGES the rules above
-# carry, pinned by the same sync test. The slug avoids the literal
-# #271/#272 substrings the canonical-rule pin selects by.
+# carry, pinned by the same sync test. The slug is free-form; the
+# #271/#272 substrings it avoids were a constraint of a selector
+# retired in #333.
 #
 # #312 sends only the two glued-honorific comma rows whose diff
 # includes `last` here ('Dr 김민준씨, V.', '田中さん, PhD'); the two

--- a/tools/differential/expected_since_2.0.0.toml
+++ b/tools/differential/expected_since_2.0.0.toml
@@ -54,17 +54,12 @@ issue = "fix(#271/#272/#298) native-script CJK: family-first order, hangul segme
 # expected_since_1.4.0.toml rather than rewritten in literal
 # characters, so the two ledgers spell the same class the same way.
 #
-# Be aware of what does NOT hold here: tests/v2/test_regex_sync.py pins
-# the 1.4 ledger's copy against _policy._SCRIPT_RANGES by hardcoded
-# filename, so THIS copy is unpinned. A span removed from the script
-# table forces the 1.4 rule to narrow, test-driven, while this twin
-# stays wide and starts classifying real regressions as intended. The
-# same gap covers the honorific alternations below, hand-copied from
-# SUFFIX_NOT_ACRONYMS and GLUED_HONORIFICS (both verified equal to
-# their sources 2026-08-05). Parametrizing those pins over every
-# expected_since_*.toml is the fix; it needs the #271/#272 selector
-# reworked first, since it asserts uniqueness and this file has two
-# such rules.
+# tests/v2/test_regex_sync.py pins this copy, and the honorific
+# alternations below, by sweeping every expected_since_*.toml rather
+# than naming one (#333). A span removed from the script table, or an
+# entry removed from SUFFIX_NOT_ACRONYMS or GLUED_HONORIFICS, now
+# forces this file to narrow with it instead of leaving a wide twin
+# behind to classify a real regression as intended.
 name_regex = "[\\u3005-\\u3006\\u3040-\\u309F\\u30A0-\\u30FF\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF\\uAC00-\\uD7A3\\uFF65-\\uFF65]"
 fields = ["given", "middle", "family", "_ambiguities"]
 


### PR DESCRIPTION
Closes #333.

`tests/v2/test_regex_sync.py` pinned the differential harness's hand copies by hardcoding `expected_since_1.4.0.toml`, so the four hand copies added to `expected_since_2.0.0.toml` in #332 were unchecked. This makes the pins sweep every `expected_since_*.toml`.

## The four copies, now pinned

| ledger line | copied from | pinned by |
|---|---|---|
| `expected_since_2.0.0.toml:63` | `_policy._SCRIPT_RANGES` | `test_every_span_bearing_rule_matches_the_script_ranges[expected_since_2.0.0.toml]` |
| `expected_since_2.0.0.toml:229` | `_policy._SCRIPT_RANGES`, inside the #298 lookahead | same |
| `expected_since_2.0.0.toml:162` | CJK members of `SUFFIX_NOT_ACRONYMS` | `test_differential_honorific_rules_match_their_vocabulary` |
| `expected_since_2.0.0.toml:116` | `GLUED_HONORIFICS` | same |

`GLUED_HONORIFICS` had **no** pinned copy anywhere in the tree before this.

## What changed, and why it wasn't a one-line glob

**The `#271`/`#272` selector is retired.** `test_differential_cjk_rule_matches_the_script_ranges` selected rules by issue substring and asserted uniqueness; the 2.0 ledger has two matching rules, so #332 broke it. Its equality check was already fully subsumed by the span-bearing sweep — the canonical rule is itself span-bearing — so only its two table-level guards were load-bearing. Those move to `test_script_ranges_membership_is_decided`, which names no ledger. The sweep now owns "every hand copy equals the table" and that test owns "the table didn't change shape without a decision", so a selector break can't take the decision gate out as collateral. Rule authors may now cite #271/#272 in compound slugs freely — the old docstring forbade it.

**The span-bearing floor is per-file and recorded.** `_SPAN_BEARING_FLOORS` maps each ledger to its known count, and membership is asserted — a new baseline's ledger fails as *unrecorded* rather than passing unmeasured. It's `>=`, not `==`: a newly added span-bearing rule is pinned by discovery the moment it exists, so the number's only job is catching a copy that fell *out* of reach.

**The honorific pin needed more than a glob.** It read its alternation by asserting the rule starts with `(?:^| )(?:` and ends with `)$`. Neither 2.0 rule is anchored that way, so pointing the old parser at the file would have failed on shape, not content. Replaced with a generic extractor over `(?:a|b|c)` groups carrying a script-classified member, plus `_HONORIFIC_SOURCES` declaring which constant each rule mirrors. A roster rather than inferring the source, because `GLUED_HONORIFICS <= SUFFIX_NOT_ACRONYMS` is asserted at `config/suffixes.py:848` — the sets are nested, so "equals one of the two known sets" would let a spaced rule that silently narrowed to exactly the glued set pass by matching the other member.

**The nickname delimiter check sweeps too.** It asserted exactly one such rule in the hardcoded file; 2.0 has zero, so neither a per-file nor a global count is a true invariant. Also folds away a dead branch — the two spellings it compared against were the same string, since a unicode escape in a non-raw literal is already the character it names.

## Two corrections to the issue text

Both re-measured against the working tree on 2026-08-07:

- The global span-bearing count after sweeping is **6, not 5**. The 1.4 ledger contributes **4**, not 3.
- The existing `assert len(checked) >= 3` floor and its comment ("the canonical rule plus **both** compound rules") were **already one behind**: the 1.4 ledger has three compound rules, not two.

## Verification

Each pin was demonstrated non-inert by mutating its source and confirming failure, not by asserting it works:

- Corrupting the hangul span in both 2.0 copies passed 25/25 on the old suite — the bug, shown rather than argued — and fails the new sweep.
- Removing `教授` from both `SUFFIX_NOT_ACRONYMS` and `GLUED_HONORIFICS` now fails the honorific pin. Removing it from `SUFFIX_NOT_ACRONYMS` alone trips the subset assert at import instead, which proves nothing about the pin, so the stronger variant was run.
- Both roster completeness directions (stale key, undeclared copy), the `_SPAN_BEARING_FLOORS` membership and floor assertions, the ledger-glob vacuity guard, and both table guards were each shown failing.

Full suite: 3048 passed, 41 skipped, 11 xfailed. `mypy` and `ruff` clean.

## Scope

Tests and comments only — no change to `nameparser/` or `tools/differential/compare.py`. `AGENTS.md` release step 8 previously said to land this before opening the next cycle's ledger; it now says the new ledger's copies are pinned automatically, but the file must be added to `_SPAN_BEARING_FLOORS`.

## Review round (5 commits after `b09ccf4`)

A three-agent review (code quality, test coverage, comment accuracy) found no critical correctness issues but did find real gaps. Four findings converged across two reviewers independently.

**`_SPAN_BEARING_FLOORS` counts became `_SPAN_BEARING_RULES` slug sets.** A count is identity-free: a copy can leave discovery — rewritten as literal characters, say — while an unrelated span-bearing rule is added, holding the total steady with a hand copy silently unpinned. Measured passing under the count; fails now. Naming the rules also closes the `>=` hole (a ledger recorded as `0` that actually carries CJK rules was accepted, its reach guard inert forever, while `AGENTS.md` tells release engineers `0` is sometimes right) and gives the roster the staleness direction its two siblings in the module already had.

**Two notation blind spots closed.** `_declared_spans` reads one spelling, so appending `a-z` *literally* to a pinned CJK class passed both the span equality and `compare.validate_rules`' sentinel probe — letting the rule claim every Latin diff in the corpus as intended. A span-declaring class must now hold nothing besides spans. Separately, `_ALTERNATION` required a literal `(?:`, so a rule written `(씨|님|先生)` carried a copy the honorific pin could not see; it now matches plain capturing groups, guarded so lookarounds don't parse as alternations of their own syntax. Same three alternations found today.

**Three stale instructions removed from `expected_since_1.4.0.toml`** telling rule authors to keep `#271`/`#272` out of their slugs to protect the pin this PR deletes. That's the file authors actually edit when writing a rule.

**Prose corrections**, each falsified by measurement: the module docstring's test inventory (already off by one on master, widened here); `_SANCTIONED_EXTRAS`' "both span pins below" (there is one now, by this PR's own design); "an empty parametrize generates zero tests and passes vacuously" (pytest emits one *skipped* test — the conclusion stands, the mechanism was wrong); and the nickname docstring's claim that a global `== 1` is false (it is true today, just the wrong invariant).

**`AGENTS.md` step 8 now names both manual steps.** A new ledger's CJK honorific rule carries a new slug by construction, so no `_HONORIFIC_SOURCES` key covers it and the pin hard-fails as undeclared. Loud rather than silent, but step 8 is the repo's "everything you must do" list.

Review also surfaced a pre-existing defect outside this PR's scope, filed as #350: the `fix(#274)` maiden rule matches `born`, which is in no config constant, so a real `maiden`/`middle`/`family` regression on "Max Born" is classified as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

