### PR TITLE
Split fix(suffix-routing) into the rules that name its shapes (#372)

### DIFF
--- a/tests/v2/test_ledger_guards.py
+++ b/tests/v2/test_ledger_guards.py
@@ -531,7 +531,8 @@ def test_cjk_corpus_matches_the_case_table() -> None:
 #: exactly one entry. The full issue lists are the keys, not a bare
 #: '#308': both 2.0 rules cite #308 while copying different constants.
 _HONORIFIC_SOURCES: dict[str, frozenset[str]] = {
-    "cjk-honorific-suffix": SUFFIX_WORDS,               # 1.4
+    "cjk-honorific-suffix": SUFFIX_WORDS,               # 1.4, spaced
+    "cjk-glued-honorific-peel": GLUED_HONORIFICS,       # 1.4, glued (#372)
     "#307/#308/#320": SUFFIX_WORDS,                     # 2.0, spaced
     "#308/#312/#319/#320": GLUED_HONORIFICS,            # 2.0, glued
 }
@@ -1019,7 +1020,7 @@ _CORPUS_CLAIMS: dict[str, dict[str, _Claim]] = {
             _Claim(215, ('given', 'suffix', 'title'), "f16a0e79cba3"),
         "fix(comma-precomma-family) pre-comma run reads as family, not given":
             _Claim(215, ('family', 'given'), "f16a0e79cba3"),
-        "fix(suffix-routing) a trailing token routes to suffix":
+        "fix(suffix-routing) two-token name with unambiguous trailing suffix stays suffix":
             _Claim(751, ('family', 'given', 'suffix'), "231640fc7535"),
         "fix(suffix-delimiter-rendering) no-space delimiter core token kept whole":
             _Claim(0, ('suffix',), "e3b0c44298fc"),
@@ -1037,8 +1038,10 @@ _CORPUS_CLAIMS: dict[str, dict[str, _Claim]] = {
             _Claim(20, ('given', 'suffix'), "b2ea8fa59eea"),
         "fix(cjk-comma-compound) comma routing compounds with the CJK order flip":
             _Claim(20, ('family', 'given', 'middle', 'suffix', 'title'), "b2ea8fa59eea"),
+        "fix(cjk-glued-honorific-peel) glued honorific peels into suffix":
+            _Claim(34, ('family', 'given', 'suffix'), "877ab3246d33"),
         "fix(cjk-honorific-suffix) postnominal honorifics recognized, compounding with the CJK order flip":
-            _Claim(14, ('family', 'given', 'middle', 'suffix'), "d49ce901bdce"),
+            _Claim(19, ('family', 'given', 'middle', 'suffix'), "aa475ddd4745"),
         "feat(#269) non-Latin titles/conjunctions recognized":
             _Claim(2, ('given', 'middle', 'title'), "c14187bb08f8"),
         "fix(leading-credential) a split 'Ph. D.' before the name stays one unit":
@@ -1178,8 +1181,25 @@ _CROSS_RULE_WINNERS: dict[str, dict[tuple[str, tuple[str, ...]], str]] = {
             "fix(comma-precomma-family)",
         ("MD, PHD", ("family", "given")): "fix(comma-precomma-family)",
         ("Smith Jr.", ("family", "suffix")): "fix(suffix-routing)",
-        ("Andersonさん", ("given", "suffix")): "fix(suffix-routing)",
-        ("김민준씨", ("family", "given", "suffix")): "fix(suffix-routing)",
+        # the glued/spaced boundary. 'Andersonさん' and '김민준씨' left
+        # suffix-routing for a rule that names them; '김민준 씨.' is
+        # spaced and stays on the spaced rule, which #372 taught to
+        # tolerate the trailing period.
+        #
+        # '김지양' is why the glued rule copies GLUED_HONORIFICS and not
+        # SUFFIX_WORDS: 양 is absent from the glued set, so no rule
+        # NAMED for honorifics can claim a suffix diff on a given name
+        # that merely ends in one. The fields-only fix(suffix-routing)
+        # still would -- measured -- which is unchanged by #372 and is
+        # the residual cost of having a last-resort tier at all. Being
+        # absorbed by the catch-all is recoverable; being labelled
+        # 'recognized honorific' by a specific rule is not.
+        ("Andersonさん", ("given", "suffix")):
+            "fix(cjk-glued-honorific-peel)",
+        ("김민준씨", ("family", "given", "suffix")):
+            "fix(cjk-glued-honorific-peel)",
+        ("김민준 씨.", ("family", "given", "suffix")):
+            "fix(cjk-honorific-suffix)",
     },
 }
 

--- a/tests/v2/test_ledger_guards.py
+++ b/tests/v2/test_ledger_guards.py
@@ -1017,7 +1017,9 @@ _CORPUS_CLAIMS: dict[str, dict[str, _Claim]] = {
             _Claim(3, ('family', 'given', 'maiden', 'middle'), "cf5c9d671c14"),
         "fix(comma-family) lone post-comma piece routes to suffix/title, not first":
             _Claim(215, ('given', 'suffix', 'title'), "f16a0e79cba3"),
-        "fix(suffix-routing) two-token name with unambiguous trailing suffix stays suffix":
+        "fix(comma-precomma-family) pre-comma run reads as family, not given":
+            _Claim(215, ('family', 'given'), "f16a0e79cba3"),
+        "fix(suffix-routing) a trailing token routes to suffix":
             _Claim(751, ('family', 'given', 'suffix'), "231640fc7535"),
         "fix(suffix-delimiter-rendering) no-space delimiter core token kept whole":
             _Claim(0, ('suffix',), "e3b0c44298fc"),
@@ -1166,6 +1168,18 @@ _CROSS_RULE_WINNERS: dict[str, dict[tuple[str, tuple[str, ...]], str]] = {
         ("田中さん, PhD", ("family", "given", "suffix")):
             "fix(cjk-comma-compound)",
         ("田中さん, V.", ("family", "suffix")): "fix(cjk-comma-compound)",
+        # #372's suffix-routing split. 'Bob Jones, author' moves NO
+        # suffix, which is what disqualifies it from the routing rule;
+        # 'Smith Jr.' is the Latin shape that rule is named for; the two
+        # glued honorifics are the majority it also legitimately takes,
+        # and cannot be given a rule of their own -- '김민준씨' and the
+        # given name '김지양' are the same string shape.
+        ("Bob Jones, author", ("family", "given")):
+            "fix(comma-precomma-family)",
+        ("MD, PHD", ("family", "given")): "fix(comma-precomma-family)",
+        ("Smith Jr.", ("family", "suffix")): "fix(suffix-routing)",
+        ("Andersonさん", ("given", "suffix")): "fix(suffix-routing)",
+        ("김민준씨", ("family", "given", "suffix")): "fix(suffix-routing)",
     },
 }
 
@@ -1252,7 +1266,15 @@ class _Excluded(NamedTuple):
 _EXCLUSION_EFFECT: dict[str, _Excluded] = {
     "(?i)^[\\u0000-\\u024f]*\\bph\\.\\s*d\\.\\s*$":
         _Excluded(3, "5a12a8117651",
-                  ("fix(comma-family)", "fix(suffix-routing)")),
+                  # fix(comma-precomma-family) JOINED this tuple in #372,
+                  # it did not replace anything: it claims the {given,
+                  # family} readings, which it legitimately describes for a
+                  # Latin comma name, while fix(suffix-routing) still
+                  # claims the readings outside its two fields. The
+                  # exclusion refuses the name before any of the three is
+                  # reached; this records what would happen without it.
+                  ("fix(comma-family)", "fix(comma-precomma-family)",
+                   "fix(suffix-routing)")),
     '(^|[\\w.]\\s+)[("\'][^)"\']+[)"\'](\\s+\\w|\\s*$)':
         _Excluded(34, "9ea55c4c4382", ()),
 }

--- a/tools/differential/expected_since_1.4.0.toml
+++ b/tools/differential/expected_since_1.4.0.toml
@@ -180,33 +180,23 @@ name_regex = "^[\\u0000-\\u024f]*,[\\u0000-\\u024f]*$"
 fields = ["given", "family"]
 
 [[change]]
-issue = "fix(suffix-routing) a trailing token routes to suffix"
-# 'Johnson PhD' / 'Smith Jr.' / 'John V': v1 routed a lone trailing
-# suffix to family/first (no comma present); 2.0 keeps recognized
-# suffixes in `suffix`.
+issue = "fix(suffix-routing) two-token name with unambiguous trailing suffix stays suffix"
+# 'Johnson PhD' / 'Smith Jr.' / 'John V' / 'QC MP': v1 routed a lone
+# trailing suffix to family/first (no comma present); 2.0 keeps
+# recognized suffixes in `suffix`. Four corpus names, and the prose
+# fits all four.
 #
-# The issue text says "a trailing token", not "a two-token Latin
-# name", because #312's comma-less glued honorifics land here too and
-# they are the majority: '田中さん' -> 田中/さん, 'Andersonさん' ->
-# Anderson/さん, '김민준씨' -> 김/민준/씨. Every name this rule claims
-# moves a trailing token into `suffix`; the Latin two-token case is
-# four of them.
+# It claimed 25 until #372, on nothing but being the only fields-only
+# rule in any ledger: it sorts after every name_regex rule, so it
+# takes whatever nothing narrower named. The other 21 have their own
+# rules now -- fix(cjk-glued-honorific-peel) and the widened
+# fix(cjk-honorific-suffix) below for #312's honorifics,
+# fix(comma-precomma-family) above for the three names that move no
+# suffix at all.
 #
-# That is deliberate, not a gap left for later. The glued honorifics
-# CANNOT be given a name_regex rule of their own: '김민준씨' and the
-# given name '김지양' are the same string shape -- hangul ending in a
-# character that is also an honorific -- and only vocabulary plus
-# segmentation tells them apart, neither of which a regex over the
-# name string can reach. fix(cjk-honorific-suffix) below is anchored
-# to a whole trailing token for exactly that reason, and unanchoring
-# it to reach the glued forms was measured (#372) to make a future
-# suffix regression on '김지양' classify as a recognized honorific --
-# a specific rule confidently claiming a name it does not describe,
-# which is worse than this rule's honest breadth.
-#
-# So this is the last-resort tier and says so: it is the only
-# fields-only rule in any ledger, it sorts after every name_regex
-# rule, and it takes what nothing narrower could name.
+# Being last is the point of this rule and worth keeping. What is not
+# worth keeping is it being the only explanation a name ever gets:
+# when it grows, the question is which narrower rule is missing.
 fields = ["given", "family", "suffix"]
 
 [[change]]
@@ -387,6 +377,40 @@ name_regex = "(?s)(?=.*,)(?=.*[\\u3005-\\u3006\\u3040-\\u309F\\u30A0-\\u30FF\\u3
 fields = ["given", "middle", "family", "title", "suffix"]
 
 [[change]]
+issue = "fix(cjk-glued-honorific-peel) glued honorific peels into suffix"
+# '김민준씨' -> 김/민준/씨, '田中さん' -> 田中/さん, 'Andersonさん' ->
+# Anderson/さん: #312's peel, on a name with no space before the
+# honorific and no comma anywhere. 17 corpus names, which fell to the
+# fields-only fix(suffix-routing) above until #372 gave them a rule
+# that names them.
+#
+# The regex is this file's first hand copy of GLUED_HONORIFICS rather
+# than SUFFIX_WORDS, and that narrower vocabulary is the whole reason
+# this rule can exist. '김민준씨' and the given name '김지양' are the
+# same string shape -- hangul ending in a character the spaced list
+# calls an honorific -- so a rule keyed on SUFFIX_WORDS could not tell
+# them apart, and unanchoring the spaced rule below to reach the glued
+# forms would let a future suffix regression on '김지양' classify as a
+# recognized honorific. GLUED_HONORIFICS settles it in the config
+# instead: 양, 군, 氏, 殿 and 博士 are deliberately absent from it,
+# because a glued match on those collides with real given names. Same
+# copy, same pin (_HONORIFIC_SOURCES) as the 2.0 ledger's twin, whose
+# regex this is verbatim.
+#
+# `\.?(?=$|[ ,])` rather than `$`: the honorific ends a TOKEN, not
+# necessarily the string. '田中さん II' and '김민준씨 Jr.' carry a
+# Latin suffix after it, '김민준씨 (Jimmy)' a nickname.
+#
+# One spaced name lands here and is left that way, exactly as the 2.0
+# twin records: '김민준 박사님' matches on its 님, glued to 사 inside
+# 박사님. The label stays true of it -- the peel is what routes it to
+# `suffix` -- and closing the overlap needs a lookbehind asserting the
+# match is not interior to a longer listed honorific, which is more
+# machinery than a correct label is worth.
+name_regex = "(?<=[^\\s,])(?:박사님|선생님|교수님|박사|씨|님|先生|女士|小姐|教授|様|さん|さま|くん|ちゃん)\\.?(?=$|[ ,])"
+fields = ["given", "family", "suffix"]
+
+[[change]]
 issue = "fix(cjk-honorific-suffix) postnominal honorifics recognized, compounding with the CJK order flip"
 # '王小明 先生', '김민준 씨', '田中 太郎 様': #307 ships the spaced CJK
 # honorifics as suffix vocabulary, so a trailing 先生/씨/様 moves to
@@ -417,7 +441,7 @@ issue = "fix(cjk-honorific-suffix) postnominal honorifics recognized, compoundin
 # 2026-07-30 run, not assumed: #308's peel put a dozen glued names
 # in the corpus (Latin+glued like Andersonさん included) and every
 # one classified there -- none carried a middle-field diff.
-name_regex = "(?:^| )(?:씨|박사|박사님|선생님|교수님|군|양|님|先生|女士|小姐|博士|教授|様|氏|殿|さん|さま|くん|ちゃん)$"
+name_regex = "(?:^| )(?:씨|박사|박사님|선생님|교수님|군|양|님|先生|女士|小姐|博士|教授|様|氏|殿|さん|さま|くん|ちゃん)\\.?$"
 fields = ["given", "middle", "family", "suffix"]
 
 [[change]]

--- a/tools/differential/expected_since_1.4.0.toml
+++ b/tools/differential/expected_since_1.4.0.toml
@@ -160,16 +160,53 @@ name_regex = "^[\\u0000-\\u024f]*,[\\u0000-\\u024f]*$"
 fields = ["given", "title", "suffix"]
 
 [[change]]
-issue = "fix(suffix-routing) two-token name with unambiguous trailing suffix stays suffix"
-# 'Johnson PhD' / 'Mr. Johnson PhD': v1 routed a lone trailing suffix
-# to family/first (no comma present); 2.0 keeps recognized suffixes in
-# `suffix`.
-# #312: also claims comma-less glued-honorific names like
-# '威廉·莎士比亚さん' by the same {first, last, suffix} shape as any
-# glued Latin honorific. Its comma-bearing siblings never reach here:
-# they split by whether the diff moves `family` --
-# fix(cjk-comma-compound) when it does, fix(cjk-comma-honorific-peel)
-# when it does not -- both above, both keyed on a comma.
+issue = "fix(comma-precomma-family) pre-comma run reads as family, not given"
+# 'Bob Jones, author' / 'MD, PHD': the post-comma piece is a title on
+# BOTH sides -- it does not move, and no suffix moves either. What
+# changes is the pre-comma run: 1.4 read it as `first`, 2.x reads it
+# as `last`, because pre-comma is definitionally family. Diff is
+# exactly {given, family}.
+#
+# Its own rule because these have nothing to do with suffix routing:
+# they were falling to the fields-only fix(suffix-routing) below, on a
+# rule whose every other name moves a trailing token into `suffix`,
+# while these move no suffix at all (#372).
+#
+# Distinct from fix(comma-family) above by fields, not by order: that
+# rule is the lone post-comma piece moving into suffix/title and its
+# fields exclude `family`, which every name here moves. Latin-anchored
+# for the same reason it is -- a bare comma reaches every script.
+name_regex = "^[\\u0000-\\u024f]*,[\\u0000-\\u024f]*$"
+fields = ["given", "family"]
+
+[[change]]
+issue = "fix(suffix-routing) a trailing token routes to suffix"
+# 'Johnson PhD' / 'Smith Jr.' / 'John V': v1 routed a lone trailing
+# suffix to family/first (no comma present); 2.0 keeps recognized
+# suffixes in `suffix`.
+#
+# The issue text says "a trailing token", not "a two-token Latin
+# name", because #312's comma-less glued honorifics land here too and
+# they are the majority: '田中さん' -> 田中/さん, 'Andersonさん' ->
+# Anderson/さん, '김민준씨' -> 김/민준/씨. Every name this rule claims
+# moves a trailing token into `suffix`; the Latin two-token case is
+# four of them.
+#
+# That is deliberate, not a gap left for later. The glued honorifics
+# CANNOT be given a name_regex rule of their own: '김민준씨' and the
+# given name '김지양' are the same string shape -- hangul ending in a
+# character that is also an honorific -- and only vocabulary plus
+# segmentation tells them apart, neither of which a regex over the
+# name string can reach. fix(cjk-honorific-suffix) below is anchored
+# to a whole trailing token for exactly that reason, and unanchoring
+# it to reach the glued forms was measured (#372) to make a future
+# suffix regression on '김지양' classify as a recognized honorific --
+# a specific rule confidently claiming a name it does not describe,
+# which is worse than this rule's honest breadth.
+#
+# So this is the last-resort tier and says so: it is the only
+# fields-only rule in any ledger, it sorts after every name_regex
+# rule, and it takes what nothing narrower could name.
 fields = ["given", "family", "suffix"]
 
 [[change]]


### PR DESCRIPTION
The last of #372's confirmed over-claiming instances.

`fix(suffix-routing)` claimed 25 names in four shapes; its prose — *"two-token name with unambiguous trailing suffix stays suffix"* — described four. It is the **only `fields`-only rule in any ledger**, so it sorts after every `name_regex` rule and takes whatever nothing narrower named. It was never too broad; the narrower rules were missing.

## The split

| rule | names | shape |
|---|---|---|
| `fix(cjk-glued-honorific-peel)` | 17 | **new** — `김민준씨` → 김/민준/씨, `Andersonさん` → Anderson/さん |
| `fix(cjk-honorific-suffix)` | 11 | was 10 — gains `김민준 씨.` and `김민준 양.`, loses `김민준 박사님` to glued |
| `fix(comma-precomma-family)` | 3 | **new** — `Bob Jones, author`, which moves **no suffix at all** |
| `fix(suffix-routing)` | 4 | `Smith Jr.`, `John V` — exactly its original prose, restored |

Gate unmoved: `108/0` at 1.4.0, `90/0` at 2.0.0, `1/0` at 2.1.0. Suite 3218.

## A claim this PR made and had to retract

The second commit asserted the 17 glued honorifics **could not** have a rule — that `김민준씨` and the given name `김지양` are the same string shape, separable only by vocabulary and segmentation, neither reachable from a regex. Review falsified it, and the answer was sitting in the config:

```
GLUED_HONORIFICS omits: 양, 군, 氏, 殿, 博士
```

Exactly the characters whose *glued* match collides with real given names. The parser had already solved this by curating a narrower vocabulary; a regex reaches vocabulary by hand-copying it, which this ledger does routinely and pins with a sync test. **The 2.0.0 ledger has had such a rule since #308** — this adds its twin, regex verbatim, enrolled in `_HONORIFIC_SOURCES` against the same source.

The other two names were never glued at all: `김민준 씨.` and `김민준 양.` are spaced, and the spaced rule missed them only because `$` wouldn't tolerate a trailing period.

## What the residual gap actually is

A second wrong claim, corrected rather than shipped: a future suffix regression on `김지양` is **still** absorbed — by the fields-only catch-all, measured. That is unchanged by this PR and is the standing cost of having a last-resort tier.

What #372 buys is that no rule *named for honorifics* will claim it. Being taken by the catch-all is recoverable; being labelled `recognized honorific` by a specific rule is not — and that is precisely what unanchoring the spaced rule (the first design here) would have caused.

## Rosters

Four fired and were recorded: `_HONORIFIC_SOURCES` (the new vocabulary copy), `_CORPUS_CLAIMS`, `_EXCLUSION_EFFECT` (the Ph. D. entry's `absorbed_by` gained `fix(comma-precomma-family)` — it *joined*, it did not replace `fix(suffix-routing)`), and `_CROSS_RULE_WINNERS`, which gains the names on either side of the glued/spaced boundary.

## #372 after this

All three confirmed instances are closed. Ambiguity reporting and the specificity floor remain declined on the evidence in #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)