### PR TITLE
fix(_types): ParsedName repr names the token behind each ambiguity

### DIFF
--- a/nameparser/_types.py
+++ b/nameparser/_types.py
@@ -603,8 +603,12 @@ class ParsedName:
             if text:
                 lines.append(f"    {role.value}: {text!r}")
         if self.ambiguities:
-            kinds = [a.kind.value for a in self.ambiguities]
-            lines.append(f"    ambiguities: {kinds!r}")
+            items = [
+                f"{a.kind.value}: {'/'.join(t.text for t in a.tokens)}"
+                if a.tokens else a.kind.value
+                for a in self.ambiguities
+            ]
+            lines.append(f"    ambiguities: {items!r}")
         body = "\n".join(lines)
         return f"<ParsedName: [\n{body}\n]>" if lines else "<ParsedName: []>"
 

--- a/tests/v2/test_reprs.py
+++ b/tests/v2/test_reprs.py
@@ -44,7 +44,21 @@ def test_parsedname_repr_includes_ambiguities_line_when_present() -> None:
     pn = ParsedName("Van Johnson",
                     (van, Token("Johnson", Span(4, 11), Role.FAMILY)),
                     (Ambiguity(AmbiguityKind.PARTICLE_OR_GIVEN, "d", (van,)),))
-    assert "ambiguities: ['particle-or-given']" in repr(pn)
+    assert "ambiguities: ['particle-or-given: Van']" in repr(pn)
+
+
+def test_parsedname_repr_distinguishes_same_kind_ambiguities_by_token() -> None:
+    # #431: two distinct suffix-or-name ambiguities about different
+    # words must not render as identical list entries.
+    ma = Token("MA", Span(11, 13), Role.SUFFIX)
+    v = Token("V", Span(14, 15), Role.SUFFIX)
+    pn = ParsedName(
+        "John Smith MA V",
+        (Token("John", Span(0, 4), Role.GIVEN),
+         Token("Smith", Span(5, 10), Role.FAMILY), ma, v),
+        (Ambiguity(AmbiguityKind.SUFFIX_OR_NAME, "d1", (ma,)),
+         Ambiguity(AmbiguityKind.SUFFIX_OR_NAME, "d2", (v,))))
+    assert "ambiguities: ['suffix-or-name: MA', 'suffix-or-name: V']" in repr(pn)
 
 
 def test_empty_parsedname_repr() -> None:


### PR DESCRIPTION
## Summary
- `ParsedName.__repr__` rendered the `ambiguities` line as `[a.kind.value for a in self.ambiguities]`, so two distinct `Ambiguity` objects of the same kind about different words collapsed into identical-looking entries (`['suffix-or-name', 'suffix-or-name']`), reading as a double-emit bug in the emitter rather than the two separate, correctly-distinct calls they are.
- Follows `Ambiguity.__repr__`'s own token-join convention (`"/".join(t.text for t in self.tokens)`) so each entry names its token(s): `['suffix-or-name: MA', 'suffix-or-name: V']`. Falls back to bare `kind.value` when an ambiguity has no tokens (e.g. `UNBALANCED_DELIMITER`).

Fixes #431

## Test plan
- [x] Updated `tests/v2/test_reprs.py::test_parsedname_repr_includes_ambiguities_line_when_present` for the new format
- [x] Added `tests/v2/test_reprs.py::test_parsedname_repr_distinguishes_same_kind_ambiguities_by_token`, a regression test for the exact two-ambiguity case from the issue
- [x] Full suite passes: `uv run pytest -q` → 5924 passed, 154 skipped, 9 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)