### PR TITLE
Release 2.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
 repository-code: "https://github.com/derek73/python-nameparser"
 url: "https://github.com/derek73/python-nameparser"
 license: LGPL-2.1-or-later
-version: "2.2.0"
+version: "2.3.0"

--- a/docs/release_log.rst
+++ b/docs/release_log.rst
@@ -1,8 +1,23 @@
 Release Log
 ===========
-* 2.3.0 - Unreleased
+* 2.3.0 - September 12, 2026
 
-    nameparser 2.3 is under development.
+    nameparser 2.3 is parsing fixes and new honorific vocabulary;
+    nothing in the API is removed or renamed.
+
+    The fixes cluster around post-nominals and titles. A space-separated
+    run of post-nominals keeps the spacing the writer typed, and the
+    acronyms that are also surnames -- Rai, Cha, Ba -- no longer take a
+    name's family name. A run of titles addresses by its last, and a
+    trailing abbreviated title reads as a title. CJK names and honorifics
+    written with a full stop of any width now parse. The additions are
+    renunciate and royal given-name titles, Devanagari and the first
+    Bengali honorifics, and two ``AmbiguityKind`` members that report a
+    reading nothing in the name decided.
+
+    One incompatibility: a ``Lexicon`` pickled by 2.1.x or 2.2.x with a
+    caller-added wide-stop or NFD entry no longer loads; the full-stop
+    bullet below has the remedy.
 
     **Behavior Changes**
 

--- a/nameparser/_version.py
+++ b/nameparser/_version.py
@@ -15,5 +15,5 @@ VERSION = (2, 3, 0)
 #: "dev" through the cycle, cleared at release. It normalizes to
 #: 2.3.0.dev0, which sorts above 2.2.0 and BELOW 2.3.0, so an install
 #: from master can never masquerade as the release it precedes.
-PRE_RELEASE = "dev"
+PRE_RELEASE = ""
 __version__ = ".".join(map(str, VERSION)) + PRE_RELEASE


### PR DESCRIPTION
Release commit for 2.3.0 (AGENTS.md release checklist, steps 2–3).

- `nameparser/_version.py`: `PRE_RELEASE = ""`, so `__version__` is `2.3.0`
- `CITATION.cff`: `version: "2.3.0"`
- `docs/release_log.rst`: entry dated September 12, 2026, with a lead paragraph replacing "under development"

## Verification

- Differential gate, every ledger baseline, each exit 0 (1165 corpus names; unexplained 0, radar unclassified 0, no MOVED SHAPE):
  - 1.4.0: 412 intentional
  - 2.0.0: 340 intentional
  - 2.1.0: 254 intentional
  - 2.2.0: 117 intentional
- `pytest`: 7815 passed, 177 skipped, 4 xfailed
- `sphinx-build -W`: clean
- Milestone v2.3: 0 open / 54 closed. No open Dependabot PRs; #521 is milestoned 2.4.

## After merge

1. Tag the merge commit `v2.3.0`, push the tag, `gh release create v2.3.0`
2. Approve the `pypi` environment gate; confirm the publish is green
3. Close milestone v2.3
4. Open the 2.4 ledger (`DEFAULT_BASELINE`, `expected_since_2.3.0.toml`, five rosters) and bump master to `2.4.0dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)